### PR TITLE
Improve log fetching diagnostics

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,16 +214,17 @@ const server = http.createServer((req, res) => {
 
   } else if (q.pathname === "/log") {
     const hex = q.query.hex ? q.query.hex.toLowerCase() : null;
+    res.writeHead(200, { "Content-Type": "application/json" });
     if (hex) {
-      if (db[hex]) {
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify(db[hex]));
+      const records = db[hex] || [];
+      if (records.length === 0) {
+        console.warn("ℹ️  /log keine Daten für", hex);
       } else {
-        res.writeHead(404, { "Content-Type": "application/json" });
-        res.end("[]");
+        console.log("📨 /log Anfrage für", hex, "->", records.length, "Einträge");
       }
+      res.end(JSON.stringify(records));
     } else {
-      res.writeHead(200, { "Content-Type": "application/json" });
+      console.log("📨 /log Anfrage ohne hex -> vollständige Datenbank (", Object.keys(db).length, "Hex-Codes)");
       res.end(JSON.stringify(db));
     }
 

--- a/public/tracker.html
+++ b/public/tracker.html
@@ -147,19 +147,32 @@
 
     async function showLogs() {
       const hex = document.getElementById("hexInput").value.trim() || "3e0fe9";
-      const r = await fetch(`/log?hex=${encodeURIComponent(hex)}`);
-      const data = await r.json();
+      console.log("[Logs] Lade Daten für", hex);
       let html = '<div class="logs">';
-      if (!Array.isArray(data) || data.length === 0) {
-        html += 'keine Daten gefunden';
-      } else {
-        data.slice(-200).forEach(d => {
-          html += `<div class="log-entry">
+      try {
+        const r = await fetch(`/log?hex=${encodeURIComponent(hex)}`);
+        console.log("[Logs] Antwortstatus:", r.status);
+        if (!r.ok) {
+          throw new Error(`Serverantwort ${r.status}`);
+        }
+        const data = await r.json();
+        console.log("[Logs] Antwortgröße:", Array.isArray(data) ? data.length : data);
+        if (!Array.isArray(data) || data.length === 0) {
+          console.warn(`[Logs] Keine Daten für ${hex} erhalten.`);
+          html += 'keine Daten gefunden';
+        } else {
+          console.log(`[Logs] Verarbeite ${Math.min(data.length, 200)} von ${data.length} Einträgen.`);
+          data.slice(-200).forEach(d => {
+            html += `<div class="log-entry">
           ${d.callsign||d.hex} – Alt ${d.alt||'—'} ft, Speed ${d.gs||'—'} kt<br>
           Pos: ${d.lat}, ${d.lon}<br>
           <small>${d.time}</small>
         </div>`;
-        });
+          });
+        }
+      } catch (err) {
+        console.error("[Logs] Fehler beim Laden der Logs:", err);
+        html += `Fehler beim Laden der Logs (${err.message})`;
       }
       html += '</div>';
       document.getElementById("content").innerHTML = html;


### PR DESCRIPTION
## Summary
- add browser-side status checking and console diagnostics when loading tracker logs
- return an empty list with HTTP 200 for unknown hex queries on /log and log incoming requests for debugging

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68c83d7718408331a5d31c3f20907e64