### PR TITLE
Refactor scraper to async operations and improve UI feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@types/node": "^18.0.6",
-        "node-fetch": "^3.2.6",
         "puppeteer": "^20.9.0"
       }
     },
@@ -82,7 +80,8 @@
     "node_modules/@types/node": {
       "version": "18.0.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
-      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw=="
+      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==",
+      "optional": true
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
@@ -304,14 +303,6 @@
         }
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -461,39 +452,6 @@
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dependencies": {
         "pend": "~1.2.0"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
-      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-extra": {
@@ -705,41 +663,6 @@
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/once": {
@@ -1066,14 +989,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -1248,7 +1163,8 @@
     "@types/node": {
       "version": "18.0.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
-      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw=="
+      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==",
+      "optional": true
     },
     "@types/yauzl": {
       "version": "2.10.0",
@@ -1397,11 +1313,6 @@
         }
       }
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
-    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1504,23 +1415,6 @@
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "requires": {
         "pend": "~1.2.0"
-      }
-    },
-    "fetch-blob": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.5.tgz",
-      "integrity": "sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==",
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "requires": {
-        "fetch-blob": "^3.1.2"
       }
     },
     "fs-extra": {
@@ -1676,21 +1570,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="
-    },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
-    "node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      }
     },
     "once": {
       "version": "1.4.0",
@@ -1946,11 +1825,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@types/node": "^18.0.6",
-    "node-fetch": "^3.2.6",
     "puppeteer": "^20.9.0"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -338,6 +338,16 @@
       }
     }
 
+    function setHexStatus(message, type = "") {
+      const el = document.getElementById("hexStatus");
+      if (!el) return;
+      el.textContent = message || "";
+      el.classList.remove("success", "error");
+      if (type) {
+        el.classList.add(type);
+      }
+    }
+
     function renderMap(hex = currentHex) {
       if (!hex) {
         document.getElementById("content").innerHTML = '<div class="logs">Bitte eine ICAO Hex eingeben.</div>';
@@ -374,17 +384,32 @@
 
     async function showEvents() {
       stopSettingsInterval();
-      const r = await fetch("/events");
-      const data = await r.json();
       let html = '<div class="logs">';
-      data.forEach(ev => {
-        html += `<div class="log-entry">
-          <b>${ev.type.toUpperCase()}</b> – ${ev.callsign||ev.hex}<br>
-          Alt: ${ev.alt||'—'} ft | Speed: ${ev.gs||'—'} kt<br>
-          ${ev.lat}, ${ev.lon}<br>
-          <small>${ev.time}</small>
+
+      try {
+        const r = await fetch("/events");
+        if (!r.ok) {
+          throw new Error(`Serverantwort ${r.status}`);
+        }
+        const data = await r.json();
+        if (!Array.isArray(data) || data.length === 0) {
+          html += 'keine Events gefunden';
+        } else {
+          data.forEach(ev => {
+            html += `<div class="log-entry">
+          <b>${escapeHtml(ev.type || '').toUpperCase()}</b> – ${escapeHtml(ev.callsign||ev.hex||'—')}<br>
+          Alt: ${escapeHtml(ev.alt||'—')} ft | Speed: ${escapeHtml(ev.gs||'—')} kt<br>
+          ${escapeHtml(ev.lat||'—')}, ${escapeHtml(ev.lon||'—')}<br>
+          <small>${escapeHtml(ev.time||'')}</small>
         </div>`;
-      });
+          });
+        }
+      } catch (err) {
+        console.error("[Events] Fehler beim Laden der Events:", err);
+        const message = err && err.message ? err.message : String(err);
+        html += `Fehler beim Laden der Events (${escapeHtml(message)})`;
+      }
+
       html += '</div>';
       document.getElementById("content").innerHTML = html;
       closeSidebar();
@@ -445,18 +470,58 @@
     async function applyHex() {
       const input = document.getElementById("hexInput");
       const hex = input ? input.value.trim() : "";
-      if (hex) {
-        await fetch(`/set?hex=${encodeURIComponent(hex)}`);
+
+      if (!hex) {
+        setHexStatus("Bitte eine ICAO Hex eingeben.", "error");
+        return;
+      }
+
+      setHexStatus("Sende Anfrage...");
+
+      try {
+        const response = await fetch(`/set?hex=${encodeURIComponent(hex)}`);
+        const contentType = response.headers.get("content-type") || "";
+        let payload = null;
+
+        if (contentType.includes("application/json")) {
+          payload = await response.json();
+        } else {
+          const text = await response.text();
+          payload = text ? { message: text } : {};
+        }
+
+        if (!response.ok) {
+          const message = payload && typeof payload === "object"
+            ? payload.error || payload.message
+            : null;
+          throw new Error(message || `Serverantwort ${response.status}`);
+        }
+
         setCurrentHex(hex);
-        updateLatest();
+        await updateLatest();
+
+        const defaultMessage = `Neues Ziel gesetzt: ${hex}`;
+        const responseMessage = payload && typeof payload === "object"
+          ? payload.message || payload.error || defaultMessage
+          : defaultMessage;
+
+        setHexStatus(responseMessage, "success");
+      } catch (err) {
+        console.error("[Settings] Fehler beim Setzen des Flugzeugs:", err);
+        const message = err && err.message ? err.message : "Flugzeug konnte nicht gesetzt werden.";
+        setHexStatus(message, "error");
       }
     }
 
     async function updateLatest() {
-      const res = await fetch("/latest");
-      const d = await res.json();
-      if (!d.time) return;
-      const row = `<tr>
+      try {
+        const res = await fetch("/latest");
+        if (!res.ok) {
+          throw new Error(`Serverantwort ${res.status}`);
+        }
+        const d = await res.json();
+        if (!d || !d.time) return;
+        const row = `<tr>
         <td>${d.time}</td>
         <td>${d.callsign}</td>
         <td>${d.hex}</td>
@@ -469,8 +534,11 @@
         <td>${d.vr}</td>
         <td>${d.hdg}</td>
       </tr>`;
-      const body = document.getElementById("latestBody");
-      if (body) body.innerHTML = row;
+        const body = document.getElementById("latestBody");
+        if (body) body.innerHTML = row;
+      } catch (err) {
+        console.warn("[Latest] Aktualisierung fehlgeschlagen:", err);
+      }
     }
 
     async function showSettings() {
@@ -513,6 +581,7 @@
           <label for="hexInput">ICAO Hex</label>
           <input id="hexInput" type="text" placeholder="ICAO Hex" value="${escapeHtml(currentHex)}" />
           <button class="primary-button" onclick="applyHex()">Flugzeug setzen</button>
+          <p id="hexStatus" class="search-status"></p>
         </div>
         <div class="settings-section">
           <h3>Letzter Datensatz</h3>
@@ -579,6 +648,7 @@
       </div>`;
 
       container.innerHTML = html;
+      setHexStatus("");
 
       clearPlaceSearchResults();
 


### PR DESCRIPTION
## Summary
- replace synchronous file access with async fs.promises helpers and introduce serialized page task queue to avoid concurrent scraping
- refactor the HTTP server into an async request handler with guarded /set navigation and robust JSON body parsing
- improve the settings UI with ICAO status feedback, resilient fetch handling, and graceful event/log updates

## Testing
- node --check index.js

------
https://chatgpt.com/codex/tasks/task_b_68c925f64e108331b33c8801dba2f7d8