### PR TITLE
Show event location info in tiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -488,9 +488,9 @@ function haversine(lat1, lon1, lat2, lon2) {
   return EARTH_RADIUS * c;
 }
 
-const LANDING_MATCH_RADIUS_METERS = 500;
+const PLACE_MATCH_RADIUS_METERS = 500;
 
-function categoriseLanding(record) {
+function determinePlaceForRecord(record) {
   if (!record || typeof record !== "object") {
     return { type: "external" };
   }
@@ -533,7 +533,7 @@ function categoriseLanding(record) {
     }
   }
 
-  if (nearest && nearestDistance <= LANDING_MATCH_RADIUS_METERS) {
+  if (nearest && nearestDistance <= PLACE_MATCH_RADIUS_METERS) {
     const { place, lat: placeLat, lon: placeLon } = nearest;
     const name =
       typeof place.name === "string" && place.name.trim()
@@ -659,7 +659,7 @@ async function detectEventByLastSeen(record) {
       if (prevStatus === "online" &&
           state.lastBelowThreshold !== null &&
           timestamp - state.lastBelowThreshold <= EVENT_WINDOW_MS) {
-        const place = categoriseLanding(record);
+        const place = determinePlaceForRecord(record);
         await registerEvent("landing", record, { place });
       }
     }
@@ -671,7 +671,8 @@ async function detectEventByLastSeen(record) {
     if (timestamp - changeTime <= EVENT_WINDOW_MS) {
       if (exceedsAltitude || exceedsSpeed) {
         if (!skipInitialAirborne) {
-          await registerEvent("takeoff", record);
+          const place = determinePlaceForRecord(record);
+          await registerEvent("takeoff", record, { place });
         }
         state.pendingTakeoff = null;
       }

--- a/public/index.html
+++ b/public/index.html
@@ -492,13 +492,12 @@
             const hasCoords = Number.isFinite(latNum) && Number.isFinite(lonNum);
             const latParam = hasCoords ? latNum.toFixed(6) : "null";
             const lonParam = hasCoords ? lonNum.toFixed(6) : "null";
-            const place = ev && ev.place && (ev.place.name || ev.place.type)
-              ? `<br>Ort: ${ev.place.name ? escapeHtml(ev.place.name) : "—"}${ev.place.type ? ` (${escapeHtml(ev.place.type)})` : ""}`
-              : "";
+            const locationHtml = buildEventLocationHtml(type, ev.place);
 
             const entryContent = `<b>${escapeHtml(typeRaw || '').toUpperCase()}</b> – ${escapeHtml(ev.callsign||ev.hex||'—')}<br>
           Alt: ${escapeHtml(ev.alt||'—')} ft | Speed: ${escapeHtml(ev.gs||'—')} kt<br>
-          ${escapeHtml(ev.lat||'—')}, ${escapeHtml(ev.lon||'—')}${place}<br>
+          ${locationHtml}<br>
+          ${escapeHtml(ev.lat||'—')}, ${escapeHtml(ev.lon||'—')}<br>
           <small>${escapeHtml(ev.time||'')}</small>`;
 
             if (hasCoords) {
@@ -518,6 +517,60 @@
       html += '</div>';
       document.getElementById("content").innerHTML = html;
       closeSidebar();
+    }
+
+    function buildEventLocationHtml(eventType, placeInfo) {
+      const normalizedType = typeof eventType === "string" ? eventType.toLowerCase() : "";
+      const fallback = normalizedType === "landing"
+        ? "Außenlandung"
+        : normalizedType === "takeoff"
+          ? "Außentakeoff"
+          : "Externes Ereignis";
+
+      if (placeInfo === null || placeInfo === undefined) {
+        return escapeHtml(fallback);
+      }
+
+      if (typeof placeInfo === "string") {
+        const trimmed = placeInfo.trim();
+        return trimmed ? `Ort: ${escapeHtml(trimmed)}` : escapeHtml(fallback);
+      }
+
+      if (typeof placeInfo !== "object") {
+        return escapeHtml(fallback);
+      }
+
+      const typeRaw = placeInfo.type !== undefined && placeInfo.type !== null
+        ? String(placeInfo.type).trim()
+        : "";
+
+      if (typeRaw.toLowerCase() === "external") {
+        return escapeHtml(fallback);
+      }
+
+      const nameRaw = placeInfo.name !== undefined && placeInfo.name !== null
+        ? String(placeInfo.name).trim()
+        : "";
+      const typeLabelRaw = typeRaw && typeRaw.toLowerCase() !== "unknown"
+        ? typeRaw
+        : "";
+
+      if (!nameRaw && !typeLabelRaw) {
+        return escapeHtml(fallback);
+      }
+
+      const nameHtml = nameRaw ? escapeHtml(nameRaw) : "";
+      const typeHtml = typeLabelRaw ? escapeHtml(typeLabelRaw) : "";
+
+      if (nameRaw && typeLabelRaw) {
+        return `Ort: ${nameHtml} (${typeHtml})`;
+      }
+
+      if (nameRaw) {
+        return `Ort: ${nameHtml}`;
+      }
+
+      return `Ort: ${typeHtml}`;
     }
 
     async function showLogs() {


### PR DESCRIPTION
## Summary
- reuse the place matching helper for landings and takeoffs so takeoff events capture the nearest configured place
- display the matched place or an "Außenlandung/Außentakeoff" fallback inside the event cards in the UI

## Testing
- node --check index.js

------
https://chatgpt.com/codex/tasks/task_b_68c9b7fa3c688331b208ade2248f6e64