### PR TITLE
Refine settings view to match refreshed UI spec

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,128 +19,168 @@
           },
           colors: {
             brand: {
-              red: '#E11937',
-              purple: '#6C63FF'
+              red: '#D93030',
+              purple: '#6F5DF7',
+              ink: '#1C1C1E',
+              frost: '#F5F5F7'
             }
           },
           boxShadow: {
-            card: '0 25px 65px -20px rgba(15, 23, 42, 0.3)'
+            card: '0 12px 32px rgba(28, 28, 30, 0.08)',
+            glass: '0 20px 40px rgba(111, 93, 247, 0.18)'
           }
         }
       }
     };
   </script>
-</head>
-<body class="min-h-screen bg-slate-100 font-sans text-slate-900 antialiased">
-  <div class="flex min-h-[100dvh] w-full">
-    <aside
-      id="sidebar"
-      class="fixed inset-y-0 left-0 z-40 flex w-72 -translate-x-full transform flex-col justify-between gap-8 overflow-y-auto bg-slate-900/95 px-6 py-8 text-white shadow-2xl transition-all duration-300 ease-in-out lg:static lg:inset-auto lg:translate-x-0 lg:bg-slate-900 lg:shadow-none"
-    >
-      <div>
-        <div class="flex items-center gap-3 rounded-3xl bg-white/10 px-5 py-4 backdrop-blur">
-          <div class="flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-lg font-semibold uppercase tracking-wide">
-            HT
-          </div>
-          <div class="space-y-1">
-            <p class="text-[0.65rem] uppercase tracking-[0.45em] text-white/60">Control Center</p>
-            <p class="text-lg font-semibold tracking-wide">Heli Tracker</p>
-          </div>
-        </div>
-        <nav class="mt-10 space-y-2">
-          <button
-            data-view="map"
-            onclick="showADSB()"
-            class="sidebar-button group flex w-full items-center justify-between rounded-2xl px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white/70 ring-1 ring-white/5 transition-all duration-300 ease-in-out hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
-          >
-            <span class="flex items-center gap-3">
-              <span class="sidebar-icon flex h-11 w-11 items-center justify-center rounded-2xl bg-white/10 text-lg text-white/80 shadow-inner ring-1 ring-white/10 transition-all duration-300 ease-in-out">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12m-1.5 0v8.25a1.5 1.5 0 01-1.5 1.5h-3.75m-9 0H3.75a1.5 1.5 0 01-1.5-1.5V12" />
-                </svg>
-              </span>
-              <span>Map</span>
-            </span>
-            <span class="sidebar-badge rounded-full bg-white/10 px-3 py-1 text-[0.65rem] font-medium tracking-[0.4em] text-white/70 transition-all duration-300 ease-in-out">LIVE</span>
-          </button>
-          <button
-            data-view="events"
-            onclick="showEvents()"
-            class="sidebar-button group flex w-full items-center gap-3 rounded-2xl px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white/70 ring-1 ring-white/5 transition-all duration-300 ease-in-out hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
-          >
-            <span class="sidebar-icon flex h-11 w-11 items-center justify-center rounded-2xl bg-white/10 text-lg text-white/80 shadow-inner ring-1 ring-white/10 transition-all duration-300 ease-in-out">
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M3 4.5h18m-16.5 6h15m-13.5 6h12" />
-              </svg>
-            </span>
-            <span class="flex-1 text-left">Events</span>
-          </button>
-          <button
-            data-view="logs"
-            onclick="showLogs()"
-            class="sidebar-button group flex w-full items-center gap-3 rounded-2xl px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white/70 ring-1 ring-white/5 transition-all duration-300 ease-in-out hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
-          >
-            <span class="sidebar-icon flex h-11 w-11 items-center justify-center rounded-2xl bg-white/10 text-lg text-white/80 shadow-inner ring-1 ring-white/10 transition-all duration-300 ease-in-out">
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.25h13.5m-13.5 4.5h13.5m-13.5 4.5h9" />
-              </svg>
-            </span>
-            <span class="flex-1 text-left">Logs</span>
-          </button>
-          <button
-            data-view="settings"
-            onclick="showSettings()"
-            class="sidebar-button group flex w-full items-center gap-3 rounded-2xl px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white/70 ring-1 ring-white/5 transition-all duration-300 ease-in-out hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
-          >
-            <span class="sidebar-icon flex h-11 w-11 items-center justify-center rounded-2xl bg-white/10 text-lg text-white/80 shadow-inner ring-1 ring-white/10 transition-all duration-300 ease-in-out">
-              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 4.5l.41-1.233A.75.75 0 0112.38 3h.24a.75.75 0 01.72.533L13.75 4.5h1.5l.41-1.233A.75.75 0 0116.88 3h.24a.75.75 0 01.72.533L18.25 4.5m-7 16.5l-.41 1.233a.75.75 0 01-.72.533h-.24a.75.75 0 01-.72-.533L8.75 21h-1.5l-.41 1.233a.75.75 0 01-.72.533h-.24a.75.75 0 01-.72-.533L4.75 21m15-16.5H4.25a2.25 2.25 0 00-2.25 2.25v9a2.25 2.25 0 002.25 2.25h15a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25z" />
-              </svg>
-            </span>
-            <span class="flex-1 text-left">Settings</span>
-          </button>
-        </nav>
-      </div>
-      <div class="rounded-3xl bg-white/10 px-5 py-4 text-[0.7rem] uppercase tracking-[0.35em] text-white/70 backdrop-blur">
-        Stay in control. Monitor every takeoff and landing with precision.
-      </div>
-    </aside>
+  <style>
+    :root {
+      color-scheme: light;
+    }
 
-    <div class="flex min-w-0 flex-1 flex-col bg-gradient-to-br from-slate-100 via-white to-slate-200 lg:ml-72">
-      <header class="relative z-20 flex h-20 items-center justify-between bg-brand-red px-6 shadow-lg shadow-brand-red/30">
-        <div class="flex items-center gap-4">
-          <button
-            class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-white/20 bg-white/10 text-white transition hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 lg:hidden"
-            onclick="toggleSidebar()"
-            aria-label="Menü öffnen"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-6 w-6">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5m-16.5 5.25h16.5m-16.5 5.25h16.5" />
-            </svg>
-          </button>
-          <div class="space-y-1">
-            <p class="text-[0.65rem] uppercase tracking-[0.45em] text-white/70">Live Flight Monitor</p>
-            <h1 class="text-2xl font-semibold text-white">Heli Tracker</h1>
-          </div>
+    .view-panel {
+      animation: fadeInUp 0.45s ease forwards;
+    }
+
+    .nav-active-icon {
+      animation: navPulse 0.55s ease;
+    }
+
+    @keyframes fadeInUp {
+      from {
+        opacity: 0;
+        transform: translateY(16px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    @keyframes navPulse {
+      0% {
+        transform: scale(1);
+      }
+      50% {
+        transform: scale(1.12);
+      }
+      100% {
+        transform: scale(1);
+      }
+    }
+  </style>
+</head>
+<body class="min-h-screen bg-brand-frost font-sans text-brand-ink antialiased">
+  <div class="flex min-h-[100dvh] flex-col">
+    <header class="relative z-30 flex items-center justify-between bg-gradient-to-r from-brand-purple via-brand-red to-brand-purple px-4 py-4 text-white shadow-lg shadow-brand-red/30 sm:px-6">
+      <div class="flex items-center gap-4">
+        <button
+          class="inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-white/30 bg-white/20 text-white transition-transform duration-300 hover:bg-white/30 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+          onclick="toggleSidebar()"
+          aria-label="Menü öffnen"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-6 w-6">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5m-16.5 5.25h16.5m-16.5 5.25h16.5" />
+          </svg>
+        </button>
+        <div class="space-y-1">
+          <p class="text-[0.65rem] uppercase tracking-[0.45em] text-white/70">Control Center</p>
+          <h1 class="text-2xl font-semibold leading-tight">Heli Tracker</h1>
         </div>
-        <div id="headerHex" class="rounded-full bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/80">
+      </div>
+      <div class="flex items-center gap-4">
+        <div class="hidden text-right sm:block">
+          <p id="viewTitle" class="text-[0.65rem] uppercase tracking-[0.4em] text-white/70">Map</p>
+          <p class="text-sm font-medium text-white/90">Live monitoring</p>
+        </div>
+        <div id="headerHex" class="rounded-full bg-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/90">
           —
         </div>
-      </header>
+      </div>
+    </header>
 
-      <main id="content" class="relative flex-1 min-w-0 overflow-y-auto px-4 py-8 sm:px-6">
-        <div class="flex h-full items-center justify-center">
-          <div class="rounded-3xl bg-white/80 px-8 py-6 text-base font-medium text-slate-600 shadow-card backdrop-blur">
-            Lade Daten...
-          </div>
+    <main id="content" class="relative flex-1 min-w-0 overflow-y-auto px-4 pb-32 pt-6 sm:px-6 lg:px-8">
+      <div class="flex h-full items-center justify-center">
+        <div class="rounded-2xl bg-white/80 px-6 py-5 text-base font-medium text-slate-600 shadow-card backdrop-blur">
+          Lade Daten...
         </div>
-      </main>
-    </div>
+      </div>
+    </main>
+
+    <nav class="pointer-events-none fixed inset-x-0 bottom-0 z-30 px-4 pb-4">
+      <div class="pointer-events-auto mx-auto flex max-w-3xl items-center justify-around gap-3 rounded-3xl border border-white/60 bg-white/70 px-3 py-2 shadow-glass backdrop-blur-xl">
+        <button type="button" data-view="map" onclick="showADSB()" class="nav-item group flex flex-1 flex-col items-center gap-1 rounded-2xl px-3 py-2 text-[0.7rem] font-semibold text-slate-500 transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40">
+          <span class="nav-icon flex h-11 w-11 items-center justify-center rounded-2xl bg-white/60 text-slate-500 transition-all duration-300 ease-out group-hover:scale-105 group-hover:shadow-lg">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12m-1.5 0v8.25a1.5 1.5 0 01-1.5 1.5h-3.75m-9 0H3.75a1.5 1.5 0 01-1.5-1.5V12" />
+            </svg>
+          </span>
+          <span>Map</span>
+        </button>
+        <button type="button" data-view="events" onclick="showEvents()" class="nav-item group flex flex-1 flex-col items-center gap-1 rounded-2xl px-3 py-2 text-[0.7rem] font-semibold text-slate-500 transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40">
+          <span class="nav-icon flex h-11 w-11 items-center justify-center rounded-2xl bg-white/60 text-slate-500 transition-all duration-300 ease-out group-hover:scale-105 group-hover:shadow-lg">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 4.5h18m-16.5 6h15m-13.5 6h12" />
+            </svg>
+          </span>
+          <span>Events</span>
+        </button>
+        <button type="button" data-view="logs" onclick="showLogs()" class="nav-item group flex flex-1 flex-col items-center gap-1 rounded-2xl px-3 py-2 text-[0.7rem] font-semibold text-slate-500 transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40">
+          <span class="nav-icon flex h-11 w-11 items-center justify-center rounded-2xl bg-white/60 text-slate-500 transition-all duration-300 ease-out group-hover:scale-105 group-hover:shadow-lg">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.25h13.5m-13.5 4.5h13.5m-13.5 4.5h9" />
+            </svg>
+          </span>
+          <span>Logs</span>
+        </button>
+        <button type="button" data-view="settings" onclick="showSettings()" class="nav-item group flex flex-1 flex-col items-center gap-1 rounded-2xl px-3 py-2 text-[0.7rem] font-semibold text-slate-500 transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40">
+          <span class="nav-icon flex h-11 w-11 items-center justify-center rounded-2xl bg-white/60 text-slate-500 transition-all duration-300 ease-out group-hover:scale-105 group-hover:shadow-lg">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 4.5l.41-1.233A.75.75 0 0112.38 3h.24a.75.75 0 01.72.533L13.75 4.5h1.5l.41-1.233A.75.75 0 0116.88 3h.24a.75.75 0 01.72.533L18.25 4.5m-7 16.5l-.41 1.233a.75.75 0 01-.72.533h-.24a.75.75 0 01-.72-.533L8.75 21h-1.5l-.41 1.233a.75.75 0 01-.72.533h-.24a.75.75 0 01-.72-.533L4.75 21m15-16.5H4.25a2.25 2.25 0 00-2.25 2.25v9a2.25 2.25 0 002.25 2.25h15a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25z" />
+            </svg>
+          </span>
+          <span>Settings</span>
+        </button>
+      </div>
+    </nav>
   </div>
+
+  <aside
+    id="sidebar"
+    class="fixed inset-y-0 left-0 z-40 flex w-72 max-w-full -translate-x-full flex-col gap-6 overflow-y-auto border-r border-black/5 bg-white/95 px-6 py-8 text-brand-ink shadow-xl ring-1 ring-black/5 backdrop-blur transition-transform duration-300 ease-in-out"
+  >
+    <div class="flex items-center gap-3 rounded-2xl bg-brand-purple/5 px-4 py-3">
+      <div class="flex h-11 w-11 items-center justify-center rounded-xl bg-brand-purple text-sm font-semibold uppercase tracking-[0.35em] text-white">
+        HT
+      </div>
+      <div>
+        <p class="text-[0.65rem] uppercase tracking-[0.4em] text-brand-purple/70">Mission Brief</p>
+        <p class="text-base font-semibold text-brand-ink">Heli Tracker Extras</p>
+      </div>
+    </div>
+    <div class="space-y-4 text-sm text-brand-ink/70">
+      <div class="rounded-2xl bg-brand-frost px-4 py-3">
+        <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/80">About</p>
+        <p class="mt-2 leading-relaxed">Behalte alle Flugbewegungen im Blick und greife schnell auf weiterführende Informationen zu.</p>
+      </div>
+      <div class="rounded-2xl bg-brand-frost px-4 py-3">
+        <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/80">Support</p>
+        <p class="mt-2 leading-relaxed">Fragen? Kontaktiere das Ops-Team unter <span class="font-semibold text-brand-ink">ops@helitracker.app</span>.</p>
+      </div>
+      <div class="rounded-2xl bg-brand-frost px-4 py-3">
+        <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/80">Updates</p>
+        <p class="mt-2 leading-relaxed">Letzte Aktualisierung: <span id="sidebarUpdated" class="font-medium text-brand-ink">Live</span>.</p>
+      </div>
+    </div>
+    <div class="mt-auto flex flex-col gap-3">
+      <button type="button" class="inline-flex items-center justify-center rounded-2xl bg-brand-red px-4 py-3 text-sm font-semibold text-white shadow-card transition-all duration-300 hover:scale-[1.02] hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/60" onclick="closeSidebar()">Zurück zur App</button>
+      <button type="button" class="inline-flex items-center justify-center rounded-2xl border border-brand-purple/30 px-4 py-3 text-sm font-semibold text-brand-purple transition-all duration-300 hover:bg-brand-purple/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40" onclick="closeSidebar()">Logout</button>
+    </div>
+  </aside>
 
   <div
     id="overlay"
-    class="pointer-events-none fixed inset-0 z-30 bg-slate-900/60 opacity-0 transition-opacity duration-300 lg:hidden"
+    class="pointer-events-none fixed inset-0 z-30 bg-black/30 opacity-0 transition-opacity duration-300"
     onclick="closeSidebar()"
   ></div>
 
@@ -160,14 +200,27 @@
     let activeEventMap = null;
     let cachedLogOverview = [];
     let activeLogHex = null;
-    const iconBaseClasses = ["bg-white/10", "text-white/80", "shadow-inner", "ring-1", "ring-white/10"];
-    const iconActiveBaseClasses = ["bg-white", "shadow-lg", "ring-2", "ring-white/80"];
-    const iconActiveTextClasses = ["text-brand-red", "text-brand-purple", "text-sky-600", "text-emerald-600"];
-    const iconActiveMap = {
-      map: "text-brand-red",
-      events: "text-brand-purple",
-      logs: "text-sky-600",
-      settings: "text-emerald-600"
+    const navInactiveButtonClasses = ["text-slate-500", "bg-transparent", "shadow-none", "scale-100"];
+    const navActiveButtonClasses = [
+      "text-brand-purple",
+      "bg-white",
+      "shadow-[0_12px_28px_rgba(111,93,247,0.28)]",
+      "scale-[1.05]"
+    ];
+    const navInactiveIconClasses = ["bg-white/60", "text-slate-500", "shadow-none"];
+    const navActiveIconClasses = [
+      "bg-gradient-to-br",
+      "from-brand-purple/20",
+      "via-white",
+      "to-brand-red/20",
+      "text-brand-purple",
+      "shadow-[0_10px_24px_rgba(111,93,247,0.35)]"
+    ];
+    const viewTitleMap = {
+      map: "Live Map",
+      events: "Events",
+      logs: "Logs",
+      settings: "Settings"
     };
 
     window.addEventListener("DOMContentLoaded", initializeTracker);
@@ -213,38 +266,31 @@
 
     function setActiveView(view) {
       activeView = view;
-      const buttons = document.querySelectorAll('[data-view]');
+      const buttons = document.querySelectorAll('.nav-item[data-view]');
+      const viewTitle = document.getElementById("viewTitle");
+      if (viewTitle) {
+        viewTitle.textContent = viewTitleMap[view] || "Overview";
+      }
 
       buttons.forEach(button => {
-        button.classList.remove("bg-white/20", "text-white", "shadow-xl", "ring-1", "ring-white/20");
-        button.classList.add("text-white/70", "ring-1", "ring-white/5");
+        button.classList.remove(...navActiveButtonClasses, ...navInactiveButtonClasses);
+        button.classList.add(...navInactiveButtonClasses);
         button.removeAttribute("aria-current");
 
-        const icon = button.querySelector('.sidebar-icon');
+        const icon = button.querySelector('.nav-icon');
         if (icon) {
-          icon.classList.remove(...iconActiveBaseClasses, ...iconActiveTextClasses);
-          icon.classList.add(...iconBaseClasses);
-        }
-
-        const badge = button.querySelector('.sidebar-badge');
-        if (badge) {
-          badge.classList.remove("bg-white/90", "text-brand-red", "shadow");
-          badge.classList.add("bg-white/10", "text-white/70");
+          icon.classList.remove(...navActiveIconClasses, ...navInactiveIconClasses, "nav-active-icon");
+          icon.classList.add(...navInactiveIconClasses);
         }
 
         if (button.dataset.view === view) {
-          button.classList.remove("text-white/70", "ring-white/5");
-          button.classList.add("bg-white/20", "text-white", "shadow-xl", "ring-1", "ring-white/20");
+          button.classList.remove(...navInactiveButtonClasses);
+          button.classList.add(...navActiveButtonClasses);
           button.setAttribute("aria-current", "page");
 
           if (icon) {
-            icon.classList.remove(...iconBaseClasses);
-            icon.classList.add(...iconActiveBaseClasses, iconActiveMap[view] || "text-brand-red");
-          }
-
-          if (badge) {
-            badge.classList.remove("bg-white/10", "text-white/70");
-            badge.classList.add("bg-white/90", "text-brand-red", "shadow");
+            icon.classList.remove(...navInactiveIconClasses);
+            icon.classList.add(...navActiveIconClasses, "nav-active-icon");
           }
         }
       });
@@ -344,21 +390,19 @@
       const heading = currentHex ? currentHex.toUpperCase() : "—";
 
       container.innerHTML = `
-        <div class="mx-auto flex h-full w-full max-w-6xl flex-col gap-6 pb-8">
-          <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div class="space-y-1">
-              <p class="text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">Live Map</p>
-              <h2 class="text-3xl font-semibold text-slate-900">ADS-B Exchange Globe</h2>
-              <p class="text-sm text-slate-500">Fokussiert auf ${heading}.</p>
+        <section class="view-panel">
+          <div class="relative overflow-hidden rounded-[1.5rem] bg-slate-200 shadow-card ring-1 ring-black/5">
+            <div class="absolute left-4 top-4 z-10 flex flex-wrap items-center gap-2 rounded-full bg-white/85 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-brand-ink/80 backdrop-blur">
+              <span>Live Map – ADS-B Exchange Globe</span>
+              <span class="rounded-full bg-brand-purple/10 px-3 py-1 text-[0.65rem] font-semibold text-brand-purple">HEX ${heading}</span>
             </div>
-            <div class="flex items-center gap-3">
-              <span class="rounded-full bg-brand-red/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-brand-red">HEX ${heading}</span>
-            </div>
+            <iframe
+              src="https://globe.adsbexchange.com/?icao=${encodeURIComponent(currentHex)}"
+              class="h-[calc(100vh-14rem)] min-h-[24rem] w-full border-0"
+              loading="lazy"
+            ></iframe>
           </div>
-          <div class="relative h-[calc(100vh-12rem)] min-h-[26rem] overflow-hidden rounded-[2.5rem] bg-slate-200 shadow-card ring-1 ring-slate-200/70">
-            <iframe src="https://globe.adsbexchange.com/?icao=${encodeURIComponent(currentHex)}" class="absolute inset-0 h-full w-full border-0" loading="lazy"></iframe>
-          </div>
-        </div>`;
+        </section>`;
     }
 
     function openEventFromEncoded(encodedEvent) {
@@ -415,59 +459,57 @@
               href="${mapsLink}"
               target="_blank"
               rel="noopener"
-              class="inline-flex items-center gap-2 rounded-full bg-brand-purple px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-brand-purple/40 transition hover:bg-brand-purple/90"
+              class="inline-flex items-center gap-2 rounded-2xl bg-brand-purple px-5 py-3 text-sm font-semibold text-white shadow-card transition-all duration-300 hover:scale-[1.02] hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/60"
             >
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5H19.5V10.5M19.5 4.5L12 12" />
                 <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 12.75V18a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 18V6.75A2.25 2.25 0 016.75 4.5H12" />
               </svg>
-              In Maps öffnen
+              In Google Maps öffnen
             </a>`
-        : `<span class="inline-flex items-center gap-2 rounded-full bg-slate-200 px-5 py-3 text-sm font-semibold text-slate-500 opacity-70">Keine Koordinaten verfügbar</span>`;
+        : `<span class="inline-flex items-center gap-2 rounded-2xl bg-slate-200 px-5 py-3 text-sm font-semibold text-slate-500">Keine Koordinaten verfügbar</span>`;
 
       target.innerHTML = `
-        <div class="space-y-6">
-          <div class="rounded-[2.5rem] bg-white/90 p-6 shadow-card ring-1 ring-white/40 backdrop-blur">
-            <div class="flex flex-wrap items-center justify-between gap-4">
-              <div class="flex items-center gap-4">
-                <button
-                  type="button"
-                  onclick="showEvents()"
-                  class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-slate-200/60 bg-white/60 text-slate-600 shadow-sm transition hover:bg-white"
-                  aria-label="Zurück zu den Events"
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-                  </svg>
-                </button>
-                <div class="space-y-1">
-                  <p class="text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">${escapeHtml(typeLabel)}</p>
-                  <h2 class="text-2xl font-semibold text-slate-900">${escapeHtml(callsign)}</h2>
-                  <p class="text-sm text-slate-500">${escapeHtml(timeLabel)}</p>
-                </div>
+        <section class="view-panel space-y-6">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <div class="flex items-center gap-3">
+              <button
+                type="button"
+                onclick="showEvents()"
+                class="inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-brand-purple/20 bg-white px-3 text-brand-purple shadow-sm transition-transform duration-300 hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/60"
+                aria-label="Zurück zu den Events"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+                </svg>
+              </button>
+              <div class="space-y-1">
+                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/70">${escapeHtml(typeLabel)}</p>
+                <h2 class="text-2xl font-semibold text-brand-ink">${escapeHtml(callsign)}</h2>
+                <p class="text-sm text-slate-500">${escapeHtml(timeLabel)}</p>
               </div>
-              <span class="rounded-full bg-brand-purple/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple">HEX ${escapeHtml(hexLabel)}</span>
             </div>
-            <div class="relative mt-6 h-[60vh] min-h-[24rem] overflow-hidden rounded-[2rem] bg-slate-200">
+            <span class="rounded-full bg-brand-purple/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple">HEX ${escapeHtml(hexLabel)}</span>
+          </div>
+          <div class="overflow-hidden rounded-[1.5rem] shadow-card ring-1 ring-black/5">
+            <div class="relative h-[60vh] min-h-[24rem] bg-slate-200">
               <div id="eventMap" class="absolute inset-0 h-full w-full ${hasCoords ? "" : "hidden"}"></div>
-              <div id="eventMapFallback" class="absolute inset-0 flex items-center justify-center bg-slate-200 text-sm font-medium text-slate-600 ${hasCoords ? "hidden" : ""}">${escapeHtml(fallbackMessage)}</div>
-              <div id="eventMapOverlay" class="pointer-events-none absolute inset-0 bg-gradient-to-b from-slate-900/10 via-transparent to-slate-900/20 ${hasCoords ? "" : "hidden"}"></div>
+              <div id="eventMapFallback" class="absolute inset-0 flex items-center justify-center px-6 text-center text-sm font-medium text-slate-600 ${hasCoords ? "hidden" : ""}">${escapeHtml(fallbackMessage)}</div>
             </div>
-            <div class="mt-6 flex flex-wrap items-center justify-between gap-4">
+            <div class="flex flex-wrap items-center justify-between gap-3 bg-white/90 px-5 py-4 text-sm text-brand-ink backdrop-blur">
               <div>
-                <p class="text-[0.65rem] uppercase tracking-[0.4em] text-slate-400">Event Position</p>
-                <p class="mt-2 text-2xl font-semibold text-slate-900">${escapeHtml(coordinateLabel)}</p>
-                <p class="mt-2 text-sm text-slate-500">Satellitenansicht des Ereignisses.</p>
+                <p class="text-[0.65rem] uppercase tracking-[0.35em] text-slate-400">Event Position</p>
+                <p class="mt-1 text-lg font-semibold text-brand-ink">${escapeHtml(coordinateLabel)}</p>
               </div>
               ${mapAction}
             </div>
           </div>
-          <div class="grid gap-4 sm:grid-cols-3">
+          <div class="grid gap-3 sm:grid-cols-3">
             ${createInfoCard("Ort", locationLabel)}
             ${createInfoCard("Speed", speedLabel)}
             ${createInfoCard("Altitude", altitudeLabel)}
           </div>
-        </div>`;
+        </section>`;
 
       target.scrollTop = 0;
 
@@ -477,7 +519,6 @@
 
       const mapContainer = document.getElementById("eventMap");
       const fallbackEl = document.getElementById("eventMapFallback");
-      const overlayEl = document.getElementById("eventMapOverlay");
 
       if (typeof L !== "undefined" && mapContainer) {
         activeEventMap = L.map(mapContainer, { zoomControl: false });
@@ -490,9 +531,6 @@
         if (fallbackEl) {
           fallbackEl.classList.add("hidden");
         }
-        if (overlayEl) {
-          overlayEl.classList.remove("hidden");
-        }
         setTimeout(() => {
           if (activeEventMap) {
             activeEventMap.invalidateSize();
@@ -503,16 +541,13 @@
           fallbackEl.classList.remove("hidden");
           fallbackEl.textContent = "Karte konnte nicht geladen werden.";
         }
-        if (overlayEl) {
-          overlayEl.classList.add("hidden");
-        }
       }
     }
 
     function createInfoCard(label, value) {
-      return `<div class="rounded-3xl bg-white/90 px-6 py-5 shadow-card ring-1 ring-white/40 backdrop-blur">
-        <p class="text-[0.65rem] uppercase tracking-[0.4em] text-slate-400">${escapeHtml(label)}</p>
-        <p class="mt-2 text-xl font-semibold text-slate-900">${escapeHtml(value)}</p>
+      return `<div class="rounded-2xl border border-brand-purple/10 bg-white px-5 py-4 shadow-card">
+        <p class="text-[0.65rem] uppercase tracking-[0.35em] text-brand-purple/70">${escapeHtml(label)}</p>
+        <p class="mt-1 text-lg font-semibold text-brand-ink">${escapeHtml(value)}</p>
       </div>`;
     }
 
@@ -561,7 +596,7 @@
 
 
     function createEmptyCard(message) {
-      return `<div class="rounded-3xl bg-white/70 p-6 text-center text-sm font-medium text-slate-600 shadow-card backdrop-blur">${escapeHtml(message)}</div>`;
+      return `<div class="rounded-2xl bg-white/90 p-6 text-center text-sm font-medium text-slate-500 shadow-card ring-1 ring-black/5 backdrop-blur">${escapeHtml(message)}</div>`;
     }
 
     async function showEvents() {
@@ -591,9 +626,14 @@
 
         if (events.length === 0) {
           container.innerHTML = `
-            <div class="mx-auto w-full max-w-4xl space-y-6 p-4">
+            <section class="view-panel mx-auto w-full max-w-5xl space-y-6">
+              <div class="flex flex-col gap-2">
+                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/70">Events</p>
+                <h2 class="text-3xl font-semibold text-brand-ink">Aktuelle Flugbewegungen</h2>
+                <p class="text-sm text-slate-500">Noch wurden keine Takeoff- oder Landing-Events erkannt.</p>
+              </div>
               ${createEmptyCard("Noch keine Events erkannt")}
-            </div>`;
+            </section>`;
           return;
         }
 
@@ -601,8 +641,7 @@
           const typeRaw = typeof event.type === "string" ? event.type : "";
           const type = typeRaw.toLowerCase();
           const isLanding = type === "landing";
-          const icon = isLanding ? "✈️↓" : "✈️↑";
-          const accentClass = isLanding ? "bg-emerald-500/10 text-emerald-600" : "bg-brand-red/10 text-brand-red";
+          const typeLabel = typeRaw ? typeRaw.toUpperCase() : "EVENT";
 
           const callsign = escapeHtml(event.callsign || event.hex || "—");
           const altitude = escapeHtml(formatMetricValue(event.alt, "ft"));
@@ -634,67 +673,80 @@
           };
           const encodedEvent = encodeURIComponent(JSON.stringify(eventPayload));
 
-          const actionHint = hasCoords
-            ? '<div class="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-brand-purple transition-all duration-300 ease-in-out group-hover:translate-x-1">Eventdetails anzeigen<span aria-hidden="true">→</span></div>'
-            : '<div class="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-slate-400">Eventdetails anzeigen<span aria-hidden="true">→</span></div>';
+          const iconBackground = isLanding
+            ? "bg-emerald-500 text-white shadow-[0_10px_20px_rgba(16,185,129,0.35)]"
+            : "bg-brand-red text-white shadow-[0_10px_20px_rgba(217,48,48,0.35)]";
+          const iconSvg = isLanding
+            ? '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" class="h-5 w-5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 21l4-4h-3V5h-2v12H8l4 4z" /><path stroke-linecap="round" stroke-linejoin="round" d="M5 4.5h14" /></svg>'
+            : '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" class="h-5 w-5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3l-4 4h3v10h2V7h3l-4-4z" /><path stroke-linecap="round" stroke-linejoin="round" d="M5 19.5h14" /></svg>';
 
-          const attributes = `type="button" onclick="openEventFromEncoded('${encodedEvent}')"`;
+          const buttonDisabled = !hasCoords;
+          const buttonAttributes = buttonDisabled
+            ? 'type="button" disabled'
+            : `type="button" onclick="openEventFromEncoded('${encodedEvent}')"`;
+
+          const buttonClasses = buttonDisabled
+            ? "inline-flex items-center justify-between gap-2 rounded-2xl bg-slate-200 px-4 py-2 text-sm font-semibold text-slate-400"
+            : "inline-flex items-center justify-between gap-2 rounded-2xl bg-brand-purple px-4 py-2 text-sm font-semibold text-white shadow-card transition-all duration-300 hover:scale-[1.02] hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50";
 
           return `
-            <button ${attributes} class="group relative w-full overflow-hidden rounded-3xl bg-white/90 p-6 text-left shadow-card ring-1 ring-white/40 backdrop-blur transition-all duration-300 ease-in-out hover:-translate-y-1 hover:shadow-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50 disabled:cursor-not-allowed disabled:opacity-60">
-              <div class="flex items-start justify-between gap-4">
-                <div class="flex items-center gap-4">
-                  <span class="flex h-12 w-12 items-center justify-center rounded-2xl ${accentClass} text-2xl transition-all duration-300 ease-in-out group-hover:scale-105">${icon}</span>
-                  <div>
-                    <p class="text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">${escapeHtml(typeRaw || "Event")}</p>
-                    <h3 class="mt-1 text-xl font-semibold text-slate-900">${callsign}</h3>
+            <article class="group flex h-full flex-col gap-4 rounded-2xl bg-white p-4 shadow-card ring-1 ring-black/5 transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_25px_45px_rgba(111,93,247,0.2)]">
+              <div class="flex items-start justify-between gap-3">
+                <div class="flex items-start gap-3">
+                  <span class="flex h-11 w-11 items-center justify-center rounded-xl text-white transition-transform duration-300 group-hover:scale-110 ${iconBackground}">
+                    ${iconSvg}
+                  </span>
+                  <div class="space-y-1">
+                    <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">${escapeHtml(typeLabel)}</p>
+                    <h3 class="text-xl font-semibold text-brand-ink">${callsign}</h3>
+                    <p class="text-xs text-slate-500">${place}</p>
                   </div>
                 </div>
-                <span class="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-500">${time}</span>
+                <span class="rounded-full bg-sky-100 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-sky-600">${time}</span>
               </div>
-              <div class="mt-6 grid gap-4 text-sm text-slate-600 sm:grid-cols-2">
-                <div>
-                  <p class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Altitude</p>
-                  <p class="mt-2 text-base font-semibold text-slate-800">${altitude}</p>
+              <div class="grid gap-2 rounded-2xl bg-brand-frost/70 p-3 text-sm text-slate-500">
+                <div class="flex items-center justify-between">
+                  <span class="text-xs uppercase tracking-[0.3em] text-slate-400">Altitude</span>
+                  <span class="font-semibold text-brand-ink">${altitude}</span>
                 </div>
-                <div>
-                  <p class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Speed</p>
-                  <p class="mt-2 text-base font-semibold text-slate-800">${speed}</p>
+                <div class="flex items-center justify-between">
+                  <span class="text-xs uppercase tracking-[0.3em] text-slate-400">Speed</span>
+                  <span class="font-semibold text-brand-ink">${speed}</span>
                 </div>
-                <div class="sm:col-span-2">
-                  <p class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Position</p>
-                  <p class="mt-2 font-medium text-slate-700">${safePositionLabel}</p>
-                </div>
-                <div class="sm:col-span-2">
-                  <p class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Ort</p>
-                  <p class="mt-2 text-sm text-slate-500">${place}</p>
+                <div class="flex items-center justify-between">
+                  <span class="text-xs uppercase tracking-[0.3em] text-slate-400">Position</span>
+                  <span class="truncate pl-3 text-right font-semibold text-brand-ink">${safePositionLabel}</span>
                 </div>
               </div>
-              ${actionHint}
-            </button>`;
+              <div class="flex items-center justify-between">
+                <p class="text-xs uppercase tracking-[0.3em] text-slate-400">Mehr Details</p>
+                <button ${buttonAttributes} class="${buttonClasses} ${buttonDisabled ? "cursor-not-allowed" : ""}">
+                  <span>Eventdetails anzeigen</span>
+                  <span aria-hidden="true">→</span>
+                </button>
+              </div>
+            </article>`;
         }).join("");
 
-        container.innerHTML = `
-          <div class="mx-auto flex w-full max-w-6xl flex-col gap-6 pb-8">
-            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <p class="text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">Events</p>
-                <h2 class="text-3xl font-semibold text-slate-900">Takeoff & Landing</h2>
-                <p class="text-sm text-slate-500">Klicke auf ein Event, um Details zu öffnen.</p>
-              </div>
-              <span class="rounded-full bg-brand-purple/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple">Live Feed</span>
+        const grid = `<section class="view-panel mx-auto w-full max-w-6xl space-y-6 pb-8">
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/70">Events</p>
+              <h2 class="text-3xl font-semibold text-brand-ink">Aktuelle Bewegungen</h2>
+              <p class="text-sm text-slate-500">Takeoff- und Landing-Events deines gewählten Flugzeugs.</p>
             </div>
-            <div class="grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
-              ${cards}
-            </div>
-          </div>`;
+          </div>
+          <div class="grid gap-4 sm:grid-cols-2">${cards}</div>
+        </section>`;
+
+        container.innerHTML = grid;
       } catch (err) {
-        console.error("[Events] Fehler beim Laden der Events:", err);
+        console.error("[Events] Liste konnte nicht geladen werden:", err);
         const message = err && err.message ? err.message : String(err);
         container.innerHTML = `
-          <div class="mx-auto w-full max-w-4xl space-y-6 p-4">
+          <section class="view-panel mx-auto w-full max-w-4xl space-y-6 p-4">
             ${createEmptyCard(`Fehler beim Laden der Events (${escapeHtml(message)})`)}
-          </div>`;
+          </section>`;
       }
     }
 
@@ -786,9 +838,9 @@
         console.error("[Logs] Übersicht konnte nicht geladen werden:", err);
         const message = err && err.message ? err.message : String(err);
         container.innerHTML = `
-          <div class="mx-auto w-full max-w-4xl space-y-6 p-4">
+          <section class="view-panel mx-auto w-full max-w-4xl space-y-6 p-4">
             ${createEmptyCard(`Fehler beim Laden der Logs (${escapeHtml(message)})`)}
-          </div>`;
+          </section>`;
       }
     }
 
@@ -798,9 +850,9 @@
 
       if (!Array.isArray(list) || list.length === 0) {
         container.innerHTML = `
-          <div class="mx-auto w-full max-w-4xl space-y-6 p-4">
+          <section class="view-panel mx-auto w-full max-w-4xl space-y-6 p-4">
             ${createEmptyCard("Keine Logs vorhanden")}
-          </div>`;
+          </section>`;
         return;
       }
 
@@ -817,52 +869,50 @@
         const countLabel = count === 1 ? "1 Eintrag" : `${count} Einträge`;
 
         const buttonDisabled = !hex;
-        const attributes = buttonDisabled
-          ? "type=\"button\" disabled"
-          : `type=\"button\" onclick=\"openLogDetail('${escapeHtml(hex)}')\"`;
+        const buttonAttributes = buttonDisabled
+          ? 'type="button" disabled'
+          : `type="button" onclick="openLogDetail('${escapeHtml(hex)}')"`;
+        const buttonClasses = buttonDisabled
+          ? "inline-flex items-center gap-2 rounded-2xl bg-slate-200 px-4 py-2 text-sm font-semibold text-slate-400"
+          : "inline-flex items-center gap-2 rounded-2xl bg-brand-purple px-4 py-2 text-sm font-semibold text-white shadow-card transition-all duration-300 hover:scale-[1.02] hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50";
 
         return `
-          <button ${attributes} class="group relative flex w-full flex-col gap-3 rounded-3xl bg-white/90 p-5 text-left shadow-card ring-1 ring-white/40 backdrop-blur transition-all duration-300 ease-in-out hover:-translate-y-1 hover:shadow-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 disabled:cursor-not-allowed disabled:opacity-60">
-            <div class="flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">HEX ${escapeHtml(hexLabel)}</p>
-                <h3 class="mt-1 text-xl font-semibold text-slate-900">${callsign}</h3>
+          <article class="group flex flex-col gap-4 rounded-2xl bg-white p-4 shadow-card ring-1 ring-black/5 transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_25px_45px_rgba(111,93,247,0.2)]">
+            <div class="flex flex-wrap items-start justify-between gap-3">
+              <div class="space-y-2">
+                <h3 class="text-xl font-semibold text-brand-ink">${callsign}</h3>
+                <p class="text-xs uppercase tracking-[0.3em] text-slate-400">HEX ${escapeHtml(hexLabel)}</p>
+                <p class="text-sm text-slate-500">Alt: ${altitude} • Speed: ${speed}</p>
                 <p class="text-xs text-slate-400">${escapeHtml(countLabel)}</p>
               </div>
-              <span class="rounded-full bg-sky-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-sky-600">${time}</span>
+              <span class="rounded-full bg-sky-100 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-sky-600">${time}</span>
             </div>
-            <div class="grid gap-4 sm:grid-cols-2">
-              <div>
-                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Altitude</p>
-                <p class="mt-1 text-sm font-medium text-slate-700">${altitude}</p>
-              </div>
-              <div>
-                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Speed</p>
-                <p class="mt-1 text-sm font-medium text-slate-700">${speed}</p>
-              </div>
+            <div class="flex items-center justify-between">
+              <span class="text-xs uppercase tracking-[0.3em] text-slate-400">Detail</span>
+              <button ${buttonAttributes} class="${buttonClasses} ${buttonDisabled ? "cursor-not-allowed" : ""}">
+                <span>Log anzeigen</span>
+                <span aria-hidden="true">→</span>
+              </button>
             </div>
-            <div class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-sky-600 transition group-hover:translate-x-1">
-              Log anzeigen<span aria-hidden="true">→</span>
-            </div>
-          </button>`;
+          </article>`;
       }).join("");
 
       container.innerHTML = `
-        <div class="mx-auto flex w-full max-w-6xl flex-col gap-6 pb-8">
-          <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <section class="view-panel mx-auto w-full max-w-5xl space-y-6 pb-8">
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
             <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">Logs</p>
-              <h2 class="text-3xl font-semibold text-slate-900">Flugzeuge</h2>
-              <p class="text-sm text-slate-500">Wähle ein Flugzeug, um den vollständigen Log zu sehen.</p>
+              <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/70">Logs</p>
+              <h2 class="text-3xl font-semibold text-brand-ink">Flugdatensätze</h2>
+              <p class="text-sm text-slate-500">Wähle ein Flugzeug, um die vollständigen Rohdaten einzusehen.</p>
             </div>
-            <button type="button" class="inline-flex items-center gap-2 rounded-full bg-sky-500 px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white shadow-lg shadow-sky-500/30 transition hover:bg-sky-500/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300" onclick="loadLogOverview()">
+            <button type="button" class="inline-flex items-center gap-2 rounded-2xl bg-sky-500 px-5 py-3 text-sm font-semibold text-white shadow-card transition-all duration-300 hover:scale-[1.02] hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400" onclick="loadLogOverview()">
               Aktualisieren
             </button>
           </div>
-          <div class="grid gap-4 lg:grid-cols-2">
+          <div class="flex flex-col gap-4">
             ${cards}
           </div>
-        </div>`;
+        </section>`;
     }
 
     async function openLogDetail(hex) {
@@ -894,12 +944,12 @@
         if (!container) return;
         const message = err && err.message ? err.message : String(err);
         container.innerHTML = `
-          <div class="mx-auto w-full max-w-4xl space-y-6 p-4">
+          <section class="view-panel mx-auto w-full max-w-4xl space-y-6 p-4">
             ${createEmptyCard(`Fehler beim Laden des Logs (${escapeHtml(message)})`)}
             <div class="flex justify-center">
-              <button type="button" class="inline-flex items-center gap-2 rounded-full bg-sky-500 px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white shadow-lg shadow-sky-500/30 transition hover:bg-sky-500/90" onclick="returnToLogOverview()">Zurück</button>
+              <button type="button" class="inline-flex items-center gap-2 rounded-2xl bg-sky-500 px-5 py-3 text-sm font-semibold text-white shadow-card transition-all duration-300 hover:scale-[1.02] hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400" onclick="returnToLogOverview()">Zurück</button>
             </div>
-          </div>`;
+          </section>`;
       }
     }
 
@@ -909,12 +959,12 @@
 
       if (!Array.isArray(data) || data.length === 0) {
         container.innerHTML = `
-          <div class="mx-auto w-full max-w-4xl space-y-6 p-4">
+          <section class="view-panel mx-auto w-full max-w-4xl space-y-6 p-4">
             ${createEmptyCard("Keine Log-Einträge vorhanden")}
             <div class="flex justify-center">
-              <button type="button" class="inline-flex items-center gap-2 rounded-full bg-sky-500 px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white shadow-lg shadow-sky-500/30 transition hover:bg-sky-500/90" onclick="returnToLogOverview()">Zurück</button>
+              <button type="button" class="inline-flex items-center gap-2 rounded-2xl bg-sky-500 px-5 py-3 text-sm font-semibold text-white shadow-card transition-all duration-300 hover:scale-[1.02] hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400" onclick="returnToLogOverview()">Zurück</button>
             </div>
-          </div>`;
+          </section>`;
         return;
       }
 
@@ -954,30 +1004,30 @@
       const headingHex = hex ? hex.toUpperCase() : "—";
 
       container.innerHTML = `
-        <div class="mx-auto flex w-full max-w-6xl flex-col gap-6 pb-8">
-          <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <section class="view-panel mx-auto w-full max-w-6xl space-y-6 pb-8">
+          <div class="flex flex-wrap items-center justify-between gap-4">
             <div class="flex items-center gap-3">
-              <button type="button" onclick="returnToLogOverview()" class="inline-flex h-11 w-11 items-center justify-center rounded-full border border-slate-200/60 bg-white/70 text-slate-600 shadow-sm transition hover:bg-white" aria-label="Zurück zur Übersicht">
+              <button type="button" onclick="returnToLogOverview()" class="inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-brand-purple/20 bg-white text-brand-purple shadow-sm transition-transform duration-300 hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/60" aria-label="Zurück zur Übersicht">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
                 </svg>
               </button>
               <div>
-                <p class="text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">Log</p>
-                <h2 class="text-3xl font-semibold text-slate-900">${escapeHtml(callsign || "Flugzeug")}</h2>
+                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/70">Log Detail</p>
+                <h2 class="text-3xl font-semibold text-brand-ink">${escapeHtml(callsign || "Flugzeug")}</h2>
                 <p class="text-sm text-slate-500">HEX ${escapeHtml(headingHex)}</p>
               </div>
             </div>
-            <span class="rounded-full bg-sky-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-sky-600">${escapeHtml(formatDateTime(limited[0]?.time))}</span>
+            <span class="rounded-full bg-brand-purple/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple">${escapeHtml(formatDateTime(limited[0]?.time))}</span>
           </div>
-          <div class="rounded-3xl bg-white/90 shadow-card ring-1 ring-white/40 backdrop-blur">
-            <div class="max-h-[70vh] overflow-x-auto overflow-y-auto">
-              <table class="min-w-full table-fixed divide-y divide-slate-100 text-left">
-                <thead class="sticky top-0 bg-white/95 backdrop-blur">
-                  <tr class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+          <div class="rounded-2xl border border-brand-purple/10 bg-white shadow-card">
+            <div class="max-h-[70vh] overflow-auto">
+              <table class="min-w-full divide-y divide-slate-100 text-left">
+                <thead class="sticky top-0 bg-brand-frost/90 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                  <tr>
                     <th scope="col" class="px-4 py-3">Zeit</th>
                     <th scope="col" class="px-4 py-3">Callsign</th>
-                    <th scope="col" class="px-4 py-3">Alt</th>
+                    <th scope="col" class="px-4 py-3">Altitude</th>
                     <th scope="col" class="px-4 py-3">Speed</th>
                     <th scope="col" class="px-4 py-3">Position</th>
                   </tr>
@@ -988,7 +1038,7 @@
               </table>
             </div>
           </div>
-        </div>`;
+        </section>`;
     }
 
     function returnToLogOverview() {
@@ -1057,24 +1107,45 @@
           throw new Error(`Serverantwort ${res.status}`);
         }
         const d = await res.json();
-        const body = document.getElementById("latestBody");
-        if (d && d.time) {
-          const row = `<tr class="divide-x divide-slate-100/60">
-        <td class="px-3 py-2 text-sm font-medium text-slate-700">${escapeHtml(formatDateTime(d.time))}</td>
-        <td class="px-3 py-2 text-sm text-slate-600">${escapeHtml(d.callsign)}</td>
-        <td class="px-3 py-2 text-sm text-slate-600">${escapeHtml(d.hex)}</td>
-        <td class="px-3 py-2 text-sm text-slate-600">${escapeHtml(d.reg)}</td>
-        <td class="px-3 py-2 text-sm text-slate-600">${escapeHtml(d.type)}</td>
-        <td class="px-3 py-2 text-sm text-slate-600">${escapeHtml(d.gs)}</td>
-        <td class="px-3 py-2 text-sm text-slate-600">${escapeHtml(d.alt)}</td>
-        <td class="px-3 py-2 text-sm text-slate-600">${escapeHtml(d.lat)}</td>
-        <td class="px-3 py-2 text-sm text-slate-600">${escapeHtml(d.lon)}</td>
-        <td class="px-3 py-2 text-sm text-slate-600">${escapeHtml(d.vr)}</td>
-        <td class="px-3 py-2 text-sm text-slate-600">${escapeHtml(d.hdg)}</td>
-      </tr>`;
-          if (body) body.innerHTML = row;
-        } else if (body) {
-          body.innerHTML = "";
+        const grid = document.getElementById("latestGrid");
+        const empty = document.getElementById("latestEmpty");
+        const timestampBadge = document.getElementById("latestTimestamp");
+        const safe = value => {
+          if (value === null || value === undefined || value === "") {
+            return escapeHtml("—");
+          }
+          return escapeHtml(String(value));
+        };
+
+        if (timestampBadge) {
+          timestampBadge.textContent = d && d.time ? formatDateTime(d.time) : "—";
+        }
+
+        if (grid) {
+          if (d && d.time) {
+            const fields = [
+              { label: "Zeit", value: safe(formatDateTime(d.time)) },
+              { label: "Callsign", value: safe(d.callsign || d.hex || "") },
+              { label: "HEX", value: safe(d.hex) },
+              { label: "Registration", value: safe(d.reg) },
+              { label: "Type", value: safe(d.type) },
+              { label: "Speed (kt)", value: safe(d.gs) },
+              { label: "Altitude (ft)", value: safe(d.alt) },
+              { label: "Lat", value: safe(formatCoordinate(d.lat)) },
+              { label: "Lon", value: safe(formatCoordinate(d.lon)) },
+              { label: "Vert. Rate", value: safe(d.vr) },
+              { label: "Heading", value: safe(d.hdg) }
+            ];
+            const html = fields.map(field => `<div class="rounded-2xl border border-slate-100/80 bg-white/80 px-4 py-4 shadow-inner shadow-white/50">
+                <span class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">${field.label}</span>
+                <span class="mt-2 block text-base font-semibold text-slate-900">${field.value}</span>
+              </div>`).join("");
+            grid.innerHTML = html;
+            if (empty) empty.classList.add("hidden");
+          } else {
+            grid.innerHTML = "";
+            if (empty) empty.classList.remove("hidden");
+          }
         }
         return d;
       } catch (err) {
@@ -1122,149 +1193,132 @@
 
       const safeConfig = config || {};
       const html = `<div class="settings space-y-6">
-        <div class="settings-section rounded-3xl bg-white/90 px-6 py-6 shadow-card ring-1 ring-white/40 backdrop-blur">
-          <h3 class="text-xl font-semibold text-slate-900">Flugzeug</h3>
-          <p class="mt-2 text-sm text-slate-500">Wähle die aktuelle ICAO Hex für den Live-Feed.</p>
-          <label for="hexInput" class="mt-5 block text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">ICAO Hex</label>
-          <input id="hexInput" type="text" placeholder="ICAO Hex" value="${escapeHtml(currentHex)}" class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/70 px-4 py-3 text-base text-slate-900 shadow-inner shadow-white/40 focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" />
-          <div id="hexHistoryWrapper" class="mt-4 hidden">
-            <label class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400" for="hexHistorySelect">Gespeicherte Hex</label>
-            <div class="mt-2 flex flex-col gap-3 sm:flex-row sm:items-center">
-              <select id="hexHistorySelect" class="flex-1 rounded-2xl border border-slate-200/70 bg-white/70 px-4 py-3 text-base text-slate-900 focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" onchange="handleHexHistorySelection(event)"></select>
-              <button type="button" class="inline-flex items-center justify-center rounded-full border border-brand-red/30 bg-white/70 px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-brand-red shadow-inner shadow-white/40 transition hover:bg-white" onclick="clearHexHistory()">Liste löschen</button>
-            </div>
+        <section class="settings-section rounded-3xl bg-white/95 px-6 py-6 shadow-card ring-1 ring-white/50 backdrop-blur">
+          <div class="flex flex-col gap-1">
+            <span class="text-[0.65rem] uppercase tracking-[0.35em] text-brand-purple/70">Live Ziel</span>
+            <h3 class="text-xl font-semibold text-slate-900">Flugzeug setzen</h3>
+            <p class="text-sm text-slate-500">Wähle die aktuelle ICAO Hex für den Live-Feed.</p>
           </div>
-          <button class="primary-button mt-4 inline-flex w-full items-center justify-center rounded-full bg-brand-red px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white shadow-xl transition-all duration-300 ease-in-out hover:bg-brand-red/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/70" onclick="applyHex()">Flugzeug setzen</button>
-          <p id="hexStatus" class="mt-4 text-sm font-medium tracking-wide text-slate-500"></p>
-        </div>
-        <div class="settings-section rounded-3xl bg-white/90 px-6 py-6 shadow-card ring-1 ring-white/40 backdrop-blur">
-          <h3 class="text-xl font-semibold text-slate-900">Letzter Datensatz</h3>
-          <div class="mt-4 overflow-hidden rounded-2xl border border-slate-100/80">
-            <table class="min-w-full divide-y divide-slate-100 text-left text-xs uppercase tracking-[0.3em] text-slate-400">
-              <thead class="bg-slate-50/60">
-                <tr>
-                  <th class="px-3 py-3 font-semibold">Zeit</th>
-                  <th class="px-3 py-3 font-semibold">Callsign</th>
-                  <th class="px-3 py-3 font-semibold">Hex</th>
-                  <th class="px-3 py-3 font-semibold">Reg</th>
-                  <th class="px-3 py-3 font-semibold">Type</th>
-                  <th class="px-3 py-3 font-semibold">GS</th>
-                  <th class="px-3 py-3 font-semibold">Alt</th>
-                  <th class="px-3 py-3 font-semibold">Lat</th>
-                  <th class="px-3 py-3 font-semibold">Lon</th>
-                  <th class="px-3 py-3 font-semibold">VR</th>
-                  <th class="px-3 py-3 font-semibold">Hdg</th>
-                </tr>
-              </thead>
-              <tbody id="latestBody" class="divide-y divide-slate-100/80 bg-white/70"></tbody>
-            </table>
+          <div class="mt-6 space-y-4">
+            <div>
+              <label for="hexInput" class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">ICAO Hex</label>
+              <input id="hexInput" type="text" placeholder="ICAO Hex" value="${escapeHtml(currentHex)}" class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 text-base text-slate-900 shadow-inner shadow-white/40 transition focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" />
+            </div>
+            <div id="hexHistoryWrapper" class="hidden space-y-2">
+              <label class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400" for="hexHistorySelect">Gespeicherte Hex</label>
+              <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <select id="hexHistorySelect" class="flex-1 rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 text-base text-slate-900 transition focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" onchange="handleHexHistorySelection(event)"></select>
+                <button type="button" class="inline-flex items-center justify-center rounded-full border border-brand-red/30 bg-white/80 px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-brand-red shadow-inner shadow-white/60 transition duration-300 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/40" onclick="clearHexHistory()">Liste löschen</button>
+              </div>
+            </div>
+            <button class="inline-flex w-full items-center justify-center rounded-2xl bg-brand-red px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white shadow-lg shadow-brand-red/40 transition duration-300 hover:scale-[1.02] hover:bg-brand-red/90 hover:shadow-brand-red/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/70" onclick="applyHex()">Flugzeug setzen</button>
+            <p id="hexStatus" class="min-h-[1.5rem] text-sm font-semibold text-slate-500"></p>
           </div>
-        </div>
-        <div class="settings-section rounded-3xl bg-white/90 px-6 py-6 shadow-card ring-1 ring-white/40 backdrop-blur">
-          <h3 class="text-xl font-semibold text-slate-900">Schwellwerte</h3>
-          <form id="configForm" onsubmit="submitConfig(event)" class="mt-4 space-y-4">
+        </section>
+        <section class="settings-section rounded-3xl bg-white/95 px-6 py-6 shadow-card ring-1 ring-white/50 backdrop-blur">
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <label for="cfgAltitude" class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Höhen-Schwelle (ft)</label>
-              <input id="cfgAltitude" type="number" min="1" step="1" required class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/70 px-4 py-3 text-base text-slate-900 shadow-inner shadow-white/40 focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" />
+              <span class="text-[0.65rem] uppercase tracking-[0.35em] text-brand-purple/70">Telemetry Snapshot</span>
+              <h3 class="text-xl font-semibold text-slate-900">Letzter Datensatz</h3>
             </div>
-            <div>
-              <label for="cfgSpeed" class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Geschwindigkeits-Schwelle (kt)</label>
-              <input id="cfgSpeed" type="number" min="0" step="1" required class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/70 px-4 py-3 text-base text-slate-900 shadow-inner shadow-white/40 focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" />
+            <span id="latestTimestamp" class="inline-flex items-center rounded-full bg-sky-100 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-sky-700 shadow-inner shadow-white/40">—</span>
+          </div>
+          <div id="latestGrid" class="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4"></div>
+          <p id="latestEmpty" class="mt-4 hidden text-sm text-slate-500">Noch kein Datensatz verfügbar.</p>
+        </section>
+        <section class="settings-section rounded-3xl bg-white/95 px-6 py-6 shadow-card ring-1 ring-white/50 backdrop-blur">
+          <div class="flex flex-col gap-1">
+            <span class="text-[0.65rem] uppercase tracking-[0.35em] text-brand-purple/70">Überwachung</span>
+            <h3 class="text-xl font-semibold text-slate-900">Schwellwerte</h3>
+            <p class="text-sm text-slate-500">Passe die Trigger für Events und Warnungen an.</p>
+          </div>
+          <form id="configForm" onsubmit="submitConfig(event)" class="mt-6 space-y-5">
+            <div class="grid gap-4 md:grid-cols-3">
+              <div class="group rounded-2xl border border-slate-100/80 bg-white/80 px-4 py-4 shadow-inner shadow-white/50 transition focus-within:border-brand-purple/40 focus-within:shadow-brand-purple/10">
+                <label for="cfgAltitude" class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Höhen-Schwelle (ft)</label>
+                <input id="cfgAltitude" type="number" min="1" step="1" required class="mt-3 w-full bg-transparent text-base font-semibold text-slate-900 placeholder:text-slate-400 focus:outline-none" />
+              </div>
+              <div class="group rounded-2xl border border-slate-100/80 bg-white/80 px-4 py-4 shadow-inner shadow-white/50 transition focus-within:border-brand-purple/40 focus-within:shadow-brand-purple/10">
+                <label for="cfgSpeed" class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Geschwindigkeits-Schwelle (kt)</label>
+                <input id="cfgSpeed" type="number" min="0" step="1" required class="mt-3 w-full bg-transparent text-base font-semibold text-slate-900 placeholder:text-slate-400 focus:outline-none" />
+              </div>
+              <div class="group rounded-2xl border border-slate-100/80 bg-white/80 px-4 py-4 shadow-inner shadow-white/50 transition focus-within:border-brand-purple/40 focus-within:shadow-brand-purple/10">
+                <label for="cfgTimeout" class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Offline-Timeout (Sek.)</label>
+                <input id="cfgTimeout" type="number" min="5" step="1" required class="mt-3 w-full bg-transparent text-base font-semibold text-slate-900 placeholder:text-slate-400 focus:outline-none" />
+              </div>
             </div>
-            <div>
-              <label for="cfgTimeout" class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">Offline-Timeout (Sek.)</label>
-              <input id="cfgTimeout" type="number" min="5" step="1" required class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/70 px-4 py-3 text-base text-slate-900 shadow-inner shadow-white/40 focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" />
-            </div>
-            <button type="submit" class="inline-flex w-full items-center justify-center rounded-full bg-brand-red px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white shadow-lg shadow-brand-red/40 transition hover:bg-brand-red/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/70">Konfiguration speichern</button>
+            <button type="submit" class="inline-flex w-full items-center justify-center rounded-2xl bg-brand-red px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white shadow-lg shadow-brand-red/40 transition duration-300 hover:scale-[1.02] hover:bg-brand-red/90 hover:shadow-brand-red/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/70">Konfiguration speichern</button>
           </form>
-          <p id="configMessage" class="settings-message mt-4 text-sm font-medium tracking-wide text-slate-500"></p>
-        </div>
-        <div class="settings-section rounded-3xl bg-white/90 px-6 py-6 shadow-card ring-1 ring-white/40 backdrop-blur">
-          <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <p id="configMessage" class="mt-2 min-h-[1.5rem] text-sm font-semibold text-slate-500"></p>
+        </section>
+        <section class="settings-section rounded-3xl bg-white/95 px-6 py-6 shadow-card ring-1 ring-white/50 backdrop-blur">
+          <div class="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
             <div>
+              <span class="text-[0.65rem] uppercase tracking-[0.35em] text-brand-purple/70">Orte verwalten</span>
               <h3 class="text-xl font-semibold text-slate-900">Orte</h3>
-              <p class="mt-1 text-sm text-slate-500">Verwalte deine eigenen Landeplätze und Events.</p>
+              <p class="text-sm text-slate-500">Verwalte deine eigenen Landeplätze und Referenzpunkte.</p>
             </div>
-            <button type="button" class="inline-flex items-center gap-2 rounded-full bg-brand-purple px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white shadow-lg shadow-brand-purple/40 transition hover:bg-brand-purple/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/70" onclick="refreshPlaces()">
+            <button type="button" class="inline-flex items-center gap-2 rounded-full bg-sky-100 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-sky-700 shadow-inner shadow-white/40 transition duration-300 hover:bg-sky-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-200" onclick="refreshPlaces()">
               Aktualisieren
             </button>
           </div>
-          <div class="mt-6 overflow-hidden rounded-2xl border border-slate-100/80">
-            <table class="min-w-full divide-y divide-slate-100 text-left text-xs uppercase tracking-[0.3em] text-slate-400">
-              <thead class="bg-slate-50/60">
-                <tr>
-                  <th class="px-3 py-3 font-semibold">Name</th>
-                  <th class="px-3 py-3 font-semibold">Typ</th>
-                  <th class="px-3 py-3 font-semibold">Lat</th>
-                  <th class="px-3 py-3 font-semibold">Lon</th>
-                  <th class="px-3 py-3 font-semibold">Aktionen</th>
-                </tr>
-              </thead>
-              <tbody id="placesTableBody" class="divide-y divide-slate-100/80 bg-white/70"></tbody>
-            </table>
-          </div>
+          <div id="placesList" class="mt-6 space-y-3"></div>
           <p id="placesEmpty" class="mt-4 hidden text-sm text-slate-500">Keine Orte vorhanden.</p>
           <div class="mt-8 grid gap-4 lg:grid-cols-2">
-            <form id="placeForm" onsubmit="submitPlace(event)" class="rounded-3xl bg-white/80 px-6 py-6 shadow-inner shadow-white/40">
+            <form id="placeForm" onsubmit="submitPlace(event)" class="rounded-3xl border border-slate-100/70 bg-white/80 px-6 py-6 shadow-inner shadow-white/60">
               <h4 id="placeFormTitle" class="text-lg font-semibold text-slate-900">Neuen Ort hinzufügen</h4>
-              <label class="mt-4 text-xs font-semibold uppercase tracking-[0.35em] text-slate-400" for="placeName">Name</label>
-              <input id="placeName" type="text" class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/70 px-4 py-3 text-base text-slate-900 focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" required />
-              <label class="mt-4 text-xs font-semibold uppercase tracking-[0.35em] text-slate-400" for="placeType">Typ</label>
-              <input id="placeType" type="text" class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/70 px-4 py-3 text-base text-slate-900 focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" required />
-              <div class="mt-4 grid gap-4 sm:grid-cols-2">
+              <div class="mt-4 space-y-4">
                 <div>
-                  <label class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400" for="placeLat">Lat</label>
-                  <input id="placeLat" type="number" step="any" class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/70 px-4 py-3 text-base text-slate-900 focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" required />
+                  <label class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400" for="placeName">Name</label>
+                  <input id="placeName" type="text" class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 text-base text-slate-900 transition focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" required />
                 </div>
                 <div>
-                  <label class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400" for="placeLon">Lon</label>
-                  <input id="placeLon" type="number" step="any" class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/70 px-4 py-3 text-base text-slate-900 focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" required />
+                  <label class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400" for="placeType">Typ</label>
+                  <input id="placeType" type="text" class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 text-base text-slate-900 transition focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" required />
+                </div>
+                <div class="grid gap-4 sm:grid-cols-2">
+                  <div>
+                    <label class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400" for="placeLat">Lat</label>
+                    <input id="placeLat" type="number" step="any" class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 text-base text-slate-900 transition focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" required />
+                  </div>
+                  <div>
+                    <label class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400" for="placeLon">Lon</label>
+                    <input id="placeLon" type="number" step="any" class="mt-2 w-full rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 text-base text-slate-900 transition focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" required />
+                  </div>
                 </div>
               </div>
-              <div class="mt-5 flex flex-wrap items-center gap-3">
-                <button id="placeSubmit" type="submit" class="inline-flex flex-1 items-center justify-center rounded-full bg-brand-red px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white shadow-lg shadow-brand-red/40 transition hover:bg-brand-red/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/70">Hinzufügen</button>
-                <button id="placeCancel" type="button" class="hidden rounded-full border border-brand-red/30 bg-white/60 px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-brand-red transition hover:bg-white" onclick="cancelPlaceEdit()">Abbrechen</button>
+              <div class="mt-6 flex flex-wrap items-center gap-3">
+                <button id="placeSubmit" type="submit" class="inline-flex flex-1 items-center justify-center rounded-2xl bg-brand-red px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white shadow-lg shadow-brand-red/40 transition duration-300 hover:scale-[1.02] hover:bg-brand-red/90 hover:shadow-brand-red/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/70">Hinzufügen</button>
+                <button id="placeCancel" type="button" class="hidden rounded-2xl border border-brand-red/30 bg-white/70 px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-brand-red transition duration-300 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-red/40" onclick="cancelPlaceEdit()">Abbrechen</button>
               </div>
-              <p id="placeFormMessage" class="settings-message mt-4 text-sm font-medium tracking-wide text-slate-500"></p>
+              <p id="placeFormMessage" class="mt-4 min-h-[1.5rem] text-sm font-semibold text-slate-500"></p>
             </form>
-            <div class="rounded-3xl bg-white/80 px-6 py-6 shadow-inner shadow-white/40">
+            <div class="rounded-3xl border border-slate-100/70 bg-brand-frost/70 px-6 py-6 shadow-inner shadow-white/60">
               <h4 class="text-lg font-semibold text-slate-900">Ort suchen</h4>
-              <div class="settings search-row mt-4 flex items-center gap-3">
-                <input id="placeSearch" type="text" placeholder="Ort suchen" class="flex-1 rounded-2xl border border-slate-200/70 bg-white/70 px-4 py-3 text-base text-slate-900 focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" onkeydown="handlePlaceSearchKey(event)" />
-                <button type="button" class="rounded-full bg-brand-purple px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white shadow-lg shadow-brand-purple/40 transition hover:bg-brand-purple/90" onclick="searchPlaceInOSM()">Suche</button>
+              <div class="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+                <input id="placeSearch" type="text" placeholder="Ort suchen" class="flex-1 rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 text-base text-slate-900 transition focus:border-brand-purple focus:outline-none focus:ring-2 focus:ring-brand-purple/40" onkeydown="handlePlaceSearchKey(event)" />
+                <button type="button" class="inline-flex items-center justify-center rounded-2xl bg-brand-purple px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white shadow-lg shadow-brand-purple/40 transition duration-300 hover:scale-[1.02] hover:bg-brand-purple/90 hover:shadow-brand-purple/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/70" onclick="searchPlaceInOSM()">Suche</button>
               </div>
-              <p id="placeSearchStatus" class="mt-3 min-h-[1.5rem] text-sm font-medium text-slate-500"></p>
-              <div id="placeSearchResults" class="settings search-results mt-4 flex flex-col gap-3"></div>
+              <p id="placeSearchStatus" class="mt-3 min-h-[1.5rem] text-sm font-semibold text-slate-500"></p>
+              <div id="placeSearchResults" class="mt-4 flex flex-col gap-3"></div>
             </div>
           </div>
-        </div>
-        <div class="settings-section rounded-3xl bg-white/90 px-6 py-6 shadow-card ring-1 ring-white/40 backdrop-blur">
-          <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        </section>
+        <section class="settings-section rounded-3xl bg-white/95 px-6 py-6 shadow-card ring-1 ring-white/50 backdrop-blur">
+          <div class="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
             <div>
+              <span class="text-[0.65rem] uppercase tracking-[0.35em] text-brand-purple/70">Events</span>
               <h3 class="text-xl font-semibold text-slate-900">Events verwalten</h3>
-              <p class="mt-1 text-sm text-slate-500">Lösche erkannte Takeoff- und Landing-Events.</p>
+              <p class="text-sm text-slate-500">Lösche erkannte Takeoff- und Landing-Events.</p>
             </div>
-            <button type="button" class="inline-flex items-center gap-2 rounded-full bg-brand-purple px-5 py-3 text-sm font-semibold uppercase tracking-[0.35em] text-white shadow-lg shadow-brand-purple/40 transition hover:bg-brand-purple/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/70" onclick="refreshEventsForSettings()">
+            <button type="button" class="inline-flex items-center gap-2 rounded-full bg-sky-100 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-sky-700 shadow-inner shadow-white/40 transition duration-300 hover:bg-sky-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-200" onclick="refreshEventsForSettings()">
               Aktualisieren
             </button>
           </div>
-          <div class="mt-6 overflow-hidden rounded-2xl border border-slate-100/80">
-            <table class="min-w-full divide-y divide-slate-100 text-left text-xs uppercase tracking-[0.3em] text-slate-400">
-              <thead class="bg-slate-50/60">
-                <tr>
-                  <th class="px-3 py-3 font-semibold">Zeit</th>
-                  <th class="px-3 py-3 font-semibold">Typ</th>
-                  <th class="px-3 py-3 font-semibold">Callsign</th>
-                  <th class="px-3 py-3 font-semibold">Ort</th>
-                  <th class="px-3 py-3 font-semibold">Aktionen</th>
-                </tr>
-              </thead>
-              <tbody id="eventsTableBody" class="divide-y divide-slate-100/80 bg-white/70"></tbody>
-            </table>
-          </div>
+          <div id="eventsList" class="mt-6 space-y-3"></div>
           <p id="eventsEmpty" class="mt-4 hidden text-sm text-slate-500">Keine Events vorhanden.</p>
-          <p id="eventsMessage" class="settings-message mt-4 text-sm font-medium tracking-wide text-slate-500"></p>
-        </div>
+          <p id="eventsMessage" class="mt-4 min-h-[1.5rem] text-sm font-semibold text-slate-500"></p>
+        </section>
       </div>`;
 
       container.innerHTML = html;
@@ -1317,50 +1371,60 @@
     }
 
     function renderPlacesTable(list) {
-      const body = document.getElementById("placesTableBody");
+      const container = document.getElementById("placesList");
       const empty = document.getElementById("placesEmpty");
-      if (!body || !empty) return;
+      if (!container || !empty) return;
 
       if (!Array.isArray(list) || list.length === 0) {
-        body.innerHTML = "";
+        container.innerHTML = "";
         empty.classList.remove("hidden");
         return;
       }
 
-      const rows = list.map(place => {
+      const cards = list.map(place => {
         if (!place) return "";
         const idString = place.id !== undefined && place.id !== null ? String(place.id) : "";
         const editId = JSON.stringify(idString);
         const name = place.name !== undefined && place.name !== null ? place.name : "—";
         const type = place.type !== undefined && place.type !== null ? place.type : "—";
-        const lat = formatCoordinate(place.lat);
-        const lon = formatCoordinate(place.lon);
-        const actions = idString
-          ? `<div class="flex gap-2">
-               <button type="button" class="rounded-full bg-brand-purple/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-brand-purple transition hover:bg-brand-purple/20" onclick='startEditPlace(${editId})'>Bearbeiten</button>
-               <button type="button" class="rounded-full bg-rose-100 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-600 transition hover:bg-rose-200" onclick='deletePlace(${editId})'>Löschen</button>
-             </div>`
+        const lat = escapeHtml(formatCoordinate(place.lat));
+        const lon = escapeHtml(formatCoordinate(place.lon));
+        const actionButtons = idString
+          ? `
+              <button type="button" class="inline-flex items-center justify-center rounded-full bg-brand-purple/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-brand-purple transition duration-200 hover:bg-brand-purple/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/30" onclick='startEditPlace(${editId})'>Bearbeiten</button>
+              <button type="button" class="inline-flex items-center justify-center rounded-full bg-rose-100 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-600 transition duration-200 hover:bg-rose-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300" onclick='deletePlace(${editId})'>Löschen</button>
+            `
           : "";
-        return `<tr>
-          <td class="px-3 py-3 text-sm font-medium text-slate-700">${escapeHtml(name)}</td>
-          <td class="px-3 py-3 text-sm text-slate-600">${escapeHtml(type)}</td>
-          <td class="px-3 py-3 text-sm text-slate-600">${lat}</td>
-          <td class="px-3 py-3 text-sm text-slate-600">${lon}</td>
-          <td class="px-3 py-3">${actions}</td>
-        </tr>`;
+        return `<article class="group rounded-3xl border border-slate-100/80 bg-white/80 p-4 shadow-inner shadow-white/50 transition duration-300 hover:border-brand-purple/40 hover:shadow-brand-purple/10">
+            <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div class="flex flex-col gap-3">
+                <div class="flex flex-wrap items-center gap-3">
+                  <span class="text-base font-semibold text-slate-900">${escapeHtml(name)}</span>
+                  <span class="rounded-full bg-brand-purple/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand-purple">${escapeHtml(type)}</span>
+                </div>
+                <div class="flex flex-wrap gap-2 text-xs text-slate-500">
+                  <span class="rounded-2xl bg-brand-frost px-3 py-1 font-semibold text-slate-600">Lat: <span class="text-brand-ink">${lat}</span></span>
+                  <span class="rounded-2xl bg-brand-frost px-3 py-1 font-semibold text-slate-600">Lon: <span class="text-brand-ink">${lon}</span></span>
+                </div>
+              </div>
+              <div class="flex flex-wrap justify-end gap-2">
+                ${actionButtons}
+              </div>
+            </div>
+          </article>`;
       }).join("");
 
-      body.innerHTML = rows;
+      container.innerHTML = cards;
       empty.classList.add("hidden");
     }
 
     function renderEventsTable(list) {
-      const body = document.getElementById("eventsTableBody");
+      const container = document.getElementById("eventsList");
       const empty = document.getElementById("eventsEmpty");
-      if (!body || !empty) return;
+      if (!container || !empty) return;
 
       if (!Array.isArray(list) || list.length === 0) {
-        body.innerHTML = "";
+        container.innerHTML = "";
         empty.classList.remove("hidden");
         return;
       }
@@ -1376,28 +1440,42 @@
         return timeB - timeA;
       });
 
-      const rows = sorted.map(event => {
+      const cards = sorted.map(event => {
         if (!event) return "";
         const eventId = event.id !== undefined && event.id !== null ? String(event.id) : "";
         const time = escapeHtml(formatDateTime(event.time));
         const typeRaw = typeof event.type === "string" ? event.type : "";
+        const normalized = typeRaw.toLowerCase();
         const typeLabel = typeRaw ? typeRaw.charAt(0).toUpperCase() + typeRaw.slice(1) : "Event";
+        const chipClass = normalized === "takeoff"
+          ? "bg-brand-red/10 text-brand-red"
+          : normalized === "landing"
+            ? "bg-emerald-100 text-emerald-600"
+            : "bg-brand-purple/10 text-brand-purple";
         const callsign = escapeHtml(event.callsign || event.hex || "—");
         const placeLabel = formatEventPlace(event.place, event.type);
         const action = eventId
-          ? `<button type="button" class="rounded-full bg-rose-100 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-600 transition hover:bg-rose-200" onclick="deleteEventById('${escapeHtml(eventId)}')">Löschen</button>`
-          : `<span class="rounded-full bg-slate-100 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Nicht verfügbar</span>`;
+          ? `<button type="button" class="inline-flex items-center justify-center rounded-full bg-rose-100 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-rose-600 transition duration-200 hover:bg-rose-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-300" onclick="deleteEventById('${escapeHtml(eventId)}')">Löschen</button>`
+          : `<span class="inline-flex items-center justify-center rounded-full bg-slate-100 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Nicht verfügbar</span>`;
 
-        return `<tr>
-          <td class="px-3 py-3 text-sm font-medium text-slate-700">${time}</td>
-          <td class="px-3 py-3 text-sm text-slate-600">${escapeHtml(typeLabel)}</td>
-          <td class="px-3 py-3 text-sm text-slate-600">${callsign}</td>
-          <td class="px-3 py-3 text-sm text-slate-600">${placeLabel}</td>
-          <td class="px-3 py-3">${action}</td>
-        </tr>`;
+        return `<article class="group rounded-3xl border border-slate-100/80 bg-white/80 p-4 shadow-inner shadow-white/50 transition duration-300 hover:border-brand-purple/40 hover:shadow-brand-purple/10">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <div class="flex flex-wrap items-center gap-3">
+                <span class="inline-flex items-center rounded-full ${chipClass} px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em]">${escapeHtml(typeLabel)}</span>
+                <span class="text-base font-semibold text-slate-900">${callsign}</span>
+              </div>
+              <span class="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-sky-700">${time}</span>
+            </div>
+            <div class="mt-3 flex flex-wrap gap-2 text-xs text-slate-500">
+              <span class="rounded-2xl bg-brand-frost px-3 py-1 font-medium text-slate-600">Ort: <span class="font-semibold text-brand-ink">${placeLabel}</span></span>
+            </div>
+            <div class="mt-4 flex justify-end">
+              ${action}
+            </div>
+          </article>`;
       }).join("");
 
-      body.innerHTML = rows;
+      container.innerHTML = cards;
       empty.classList.add("hidden");
     }
 
@@ -1410,7 +1488,7 @@
       } else if (type === "error") {
         color = "text-rose-500";
       }
-      el.className = `settings-message mt-4 text-sm font-medium tracking-wide ${color}`;
+      el.className = `mt-4 min-h-[1.5rem] text-sm font-semibold ${color}`;
       el.textContent = message || "";
     }
 
@@ -1688,7 +1766,7 @@
       } else if (type === "error") {
         color = "text-rose-500";
       }
-      el.className = `mt-3 min-h-[1.5rem] text-sm font-medium ${color}`;
+      el.className = `mt-3 min-h-[1.5rem] text-sm font-semibold ${color}`;
       el.textContent = message || "";
     }
 
@@ -1705,8 +1783,8 @@
         if (!entry) return "";
         const isSelected = index === nominatimSelectedIndex;
         const classes = isSelected
-          ? "rounded-2xl border border-brand-purple/40 bg-brand-purple/5 p-4 text-sm text-slate-600 shadow-inner shadow-brand-purple/10"
-          : "rounded-2xl border border-slate-200/70 bg-white/70 p-4 text-sm text-slate-600 shadow-inner shadow-white/40";
+          ? "rounded-3xl border border-brand-purple/40 bg-brand-purple/10 p-4 text-sm text-slate-600 shadow-inner shadow-brand-purple/20"
+          : "rounded-3xl border border-slate-100/80 bg-white/80 p-4 text-sm text-slate-600 shadow-inner shadow-white/50";
         const typeLabel = entry.typeLabel || "";
         const classLabel = entry.classLabel || "";
         const detailParts = [];
@@ -1722,7 +1800,7 @@
           <div class="text-sm font-semibold text-slate-800">${escapeHtml(entry.displayName || "")}</div>
           <div class="mt-1 text-xs font-medium uppercase tracking-[0.3em] text-slate-400">${coords}</div>
           ${detailHtml}
-          <button type="button" class="mt-3 inline-flex items-center gap-2 rounded-full bg-brand-purple px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white transition hover:bg-brand-purple/90" onclick="applyNominatimResult(${index})">Koordinaten übernehmen</button>
+          <button type="button" class="mt-3 inline-flex items-center justify-center rounded-2xl bg-brand-purple px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-white shadow-lg shadow-brand-purple/40 transition duration-300 hover:scale-[1.02] hover:bg-brand-purple/90 hover:shadow-brand-purple/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/60" onclick="applyNominatimResult(${index})">Koordinaten übernehmen</button>
         </div>`;
       }).join("");
 
@@ -1845,7 +1923,7 @@
       } else if (type === "error") {
         color = "text-rose-500";
       }
-      el.className = `settings-message mt-4 text-sm font-medium tracking-wide ${color}`;
+      el.className = `mt-4 min-h-[1.5rem] text-sm font-semibold ${color}`;
       el.textContent = message || "";
     }
 
@@ -1858,7 +1936,7 @@
       } else if (type === "error") {
         color = "text-rose-500";
       }
-      el.className = `settings-message mt-4 text-sm font-medium tracking-wide ${color}`;
+      el.className = `mt-4 min-h-[1.5rem] text-sm font-semibold ${color}`;
       el.textContent = message || "";
     }
 
@@ -1984,7 +2062,7 @@
 
     function createStatusCard(message) {
       return `<div class="flex h-full items-center justify-center">
-        <div class="rounded-3xl bg-white/80 px-8 py-6 text-base font-medium text-slate-600 shadow-card backdrop-blur">${escapeHtml(message)}</div>
+        <div class="view-panel max-w-md rounded-2xl bg-white/90 px-6 py-5 text-center text-base font-medium text-slate-600 shadow-card ring-1 ring-black/5 backdrop-blur">${escapeHtml(message)}</div>
       </div>`;
     }
 


### PR DESCRIPTION
## Summary
- rebuild the settings view with modern sections for aircraft selection, latest snapshot, thresholds, places, and events management
- refactor the latest data updater to populate responsive stat cards and a timestamp badge
- update place/event management rendering plus search feedback to use the new pill and card visual language

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68cbb56f3230833197bb19cf04e4c209