### PR TITLE
Remove map overlay tile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -387,15 +387,9 @@
       const container = document.getElementById("content");
       if (!container) return;
 
-      const heading = currentHex ? currentHex.toUpperCase() : "—";
-
       container.innerHTML = `
         <section class="view-panel">
           <div class="relative overflow-hidden rounded-[1.5rem] bg-slate-200 shadow-card ring-1 ring-black/5">
-            <div class="absolute left-4 top-4 z-10 flex flex-wrap items-center gap-2 rounded-full bg-white/85 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-brand-ink/80 backdrop-blur">
-              <span>Live Map – ADS-B Exchange Globe</span>
-              <span class="rounded-full bg-brand-purple/10 px-3 py-1 text-[0.65rem] font-semibold text-brand-purple">HEX ${heading}</span>
-            </div>
             <iframe
               src="https://globe.adsbexchange.com/?icao=${encodeURIComponent(currentHex)}"
               class="h-[calc(100vh-14rem)] min-h-[24rem] w-full border-0"


### PR DESCRIPTION
## Summary
- remove the overlay tile that displayed the "Live Map – ADS-B Exchange Globe" label on the map view

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68cc15875dd08331a1eff360365eb548