### PR TITLE
Ensure service worker registration without notification API

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -307,11 +307,19 @@
       }
     }
 
-    function isNotificationSupported() {
-      return typeof window !== "undefined"
-        && "Notification" in window
+    function isServiceWorkerSupported() {
+      return typeof navigator !== "undefined"
         && "serviceWorker" in navigator
         && typeof navigator.serviceWorker !== "undefined";
+    }
+
+    function isNotificationApiAvailable() {
+      return typeof window !== "undefined"
+        && "Notification" in window;
+    }
+
+    function isNotificationSupported() {
+      return isServiceWorkerSupported() && isNotificationApiAvailable();
     }
 
     function syncNotificationPreferencesFromConfig(config) {
@@ -331,7 +339,7 @@
     }
 
     async function ensureServiceWorkerReady() {
-      if (!isNotificationSupported()) {
+      if (!isServiceWorkerSupported()) {
         return null;
       }
 
@@ -361,7 +369,7 @@
     }
 
     async function ensureNotificationPermission() {
-      if (!isNotificationSupported()) {
+      if (!isNotificationApiAvailable()) {
         return false;
       }
 


### PR DESCRIPTION
## Summary
- add dedicated helpers to detect service worker and Notification API support
- ensure the service worker registers whenever navigator.serviceWorker is available
- guard notification permission requests with a direct Notification API availability check

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68cdc41722008331a1bb5bfc1dbc69b2