### PR TITLE
Improve PWA support for iOS installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/public/index.html
+++ b/public/index.html
@@ -3,11 +3,16 @@
 <head>
   <meta charset="UTF-8" />
   <title>Heli Tracker</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
   <meta name="theme-color" content="#6F5DF7" />
+  <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+  <meta name="apple-mobile-web-app-title" content="Heli Tracker" />
+  <meta name="application-name" content="Heli Tracker" />
+  <meta name="format-detection" content="telephone=no" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-192.png" />
+  <link rel="apple-touch-icon" sizes="512x512" href="/icons/icon-512.png" />
   <link rel="manifest" href="/manifest.json" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,21 +1,28 @@
 {
   "name": "Heli Tracker",
   "short_name": "HeliTracker",
+  "id": "/",
+  "scope": "/",
   "start_url": "/",
   "display": "standalone",
+  "display_override": ["standalone"],
+  "orientation": "portrait",
   "background_color": "#6F5DF7",
   "theme_color": "#6F5DF7",
   "description": "Live-Tracking für Helikopter mit Events und Benachrichtigungen.",
+  "categories": ["navigation", "productivity"],
   "icons": [
     {
       "src": "/icons/icon-192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     },
     {
       "src": "/icons/icon-512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any"
     }
   ]
 }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,9 +1,86 @@
+const CACHE_VERSION = 'v1';
+const CACHE_NAME = `heli-tracker-cache-${CACHE_VERSION}`;
+const PRECACHE_URLS = ['/', '/index.html', '/manifest.json'];
+
 self.addEventListener('install', event => {
-  event.waitUntil(self.skipWaiting());
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(CACHE_NAME);
+      try {
+        await cache.addAll(PRECACHE_URLS);
+      } catch (error) {
+        console.warn('Pre-cache failed', error);
+      }
+      await self.skipWaiting();
+    })()
+  );
 });
 
 self.addEventListener('activate', event => {
-  event.waitUntil(self.clients.claim());
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      );
+      await self.clients.claim();
+    })()
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  const url = new URL(request.url);
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      (async () => {
+        try {
+          const networkResponse = await fetch(request);
+          const cache = await caches.open(CACHE_NAME);
+          await cache.put(request, networkResponse.clone());
+          return networkResponse;
+        } catch (error) {
+          const cache = await caches.open(CACHE_NAME);
+          const cachedResponse =
+            (await cache.match(request)) ||
+            (await cache.match('/index.html')) ||
+            (await cache.match('/'));
+          if (cachedResponse) {
+            return cachedResponse;
+          }
+          throw error;
+        }
+      })()
+    );
+    return;
+  }
+
+  if (url.origin === self.location.origin) {
+    event.respondWith(
+      (async () => {
+        const cached = await caches.match(request);
+        if (cached) {
+          return cached;
+        }
+        try {
+          const networkResponse = await fetch(request);
+          const cache = await caches.open(CACHE_NAME);
+          await cache.put(request, networkResponse.clone());
+          return networkResponse;
+        } catch (error) {
+          if (cached) {
+            return cached;
+          }
+          throw error;
+        }
+      })()
+    );
+  }
 });
 
 self.addEventListener('notificationclick', event => {


### PR DESCRIPTION
## Summary
- add iOS-specific meta tags and apple touch icons to the entry HTML
- expand the web manifest with scope, orientation and metadata for standalone installs
- enhance the service worker with offline caching support and ignore node_modules in git

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68ceca5511848331a0604923dfea8cb9