### PR TITLE
Add dashboard nav and integrate logs into settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/public/index.html
+++ b/public/index.html
@@ -114,6 +114,14 @@
 
     <nav class="pointer-events-none fixed inset-x-0 bottom-0 z-30 px-4 pb-4">
       <div class="pointer-events-auto mx-auto flex max-w-3xl items-center justify-around gap-3 rounded-3xl border border-white/60 bg-white/70 px-3 py-2 shadow-glass backdrop-blur-xl">
+        <button type="button" data-view="dashboard" onclick="showDashboard()" class="nav-item group flex flex-1 flex-col items-center gap-1 rounded-2xl px-3 py-2 text-[0.7rem] font-semibold text-slate-500 transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40">
+          <span class="nav-icon flex h-11 w-11 items-center justify-center rounded-2xl bg-white/60 text-slate-500 transition-all duration-300 ease-out group-hover:scale-105 group-hover:shadow-lg">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3.75h7.5v7.5h-7.5zM12.75 3.75h7.5v7.5h-7.5zM3.75 12.75h7.5v7.5h-7.5zM12.75 12.75h7.5v7.5h-7.5z" />
+            </svg>
+          </span>
+          <span>Dashboard</span>
+        </button>
         <button type="button" data-view="map" onclick="showADSB()" class="nav-item group flex flex-1 flex-col items-center gap-1 rounded-2xl px-3 py-2 text-[0.7rem] font-semibold text-slate-500 transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40">
           <span class="nav-icon flex h-11 w-11 items-center justify-center rounded-2xl bg-white/60 text-slate-500 transition-all duration-300 ease-out group-hover:scale-105 group-hover:shadow-lg">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
@@ -129,14 +137,6 @@
             </svg>
           </span>
           <span>Events</span>
-        </button>
-        <button type="button" data-view="logs" onclick="showLogs()" class="nav-item group flex flex-1 flex-col items-center gap-1 rounded-2xl px-3 py-2 text-[0.7rem] font-semibold text-slate-500 transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40">
-          <span class="nav-icon flex h-11 w-11 items-center justify-center rounded-2xl bg-white/60 text-slate-500 transition-all duration-300 ease-out group-hover:scale-105 group-hover:shadow-lg">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.25h13.5m-13.5 4.5h13.5m-13.5 4.5h9" />
-            </svg>
-          </span>
-          <span>Logs</span>
         </button>
         <button type="button" data-view="settings" onclick="showSettings()" class="nav-item group flex flex-1 flex-col items-center gap-1 rounded-2xl px-3 py-2 text-[0.7rem] font-semibold text-slate-500 transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40">
           <span class="nav-icon flex h-11 w-11 items-center justify-center rounded-2xl bg-white/60 text-slate-500 transition-all duration-300 ease-out group-hover:scale-105 group-hover:shadow-lg">
@@ -249,7 +249,7 @@
       "text-brand-purple",
       "shadow-[0_10px_24px_rgba(111,93,247,0.35)]"
     ];
-    const settingsSectionOrder = ["aircraft", "thresholds", "notifications", "places", "events"];
+    const settingsSectionOrder = ["aircraft", "thresholds", "notifications", "places", "events", "logs"];
     const settingsTabActiveClasses = [
       "border-brand-purple/40",
       "bg-white",
@@ -262,9 +262,9 @@
       "text-slate-500"
     ];
     const viewTitleMap = {
+      dashboard: "Dashboard",
       map: "Live Map",
       events: "Events",
-      logs: "Logs",
       settings: "Settings"
     };
 
@@ -1271,6 +1271,26 @@
       }
     }
 
+    function showDashboard() {
+      stopSettingsInterval();
+      setActiveView("dashboard");
+      closeSidebar();
+      cleanupEventMap();
+      cancelDebugNotificationTimer();
+
+      const container = document.getElementById("content");
+      if (!container) return;
+
+      container.innerHTML = `
+        <section class="view-panel mx-auto w-full max-w-5xl space-y-6 pb-8">
+          <div class="rounded-3xl bg-white/95 px-6 py-8 text-center shadow-card ring-1 ring-white/50 backdrop-blur">
+            <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/70">Dashboard</p>
+            <h2 class="mt-3 text-3xl font-semibold text-brand-ink">In Kürze verfügbar</h2>
+            <p class="mt-2 text-sm text-slate-500">Hier entsteht das zentrale Einsatz-Dashboard.</p>
+          </div>
+        </section>`;
+    }
+
     function showADSB() {
       stopSettingsInterval();
       renderMap(currentHex);
@@ -1732,21 +1752,24 @@
       return label || getFallbackLocationLabel(event.type);
     }
 
-    async function showLogs() {
-      stopSettingsInterval();
-      setActiveView("logs");
-      closeSidebar();
-      cleanupEventMap();
-      activeLogHex = null;
+    function getSettingsLogsContainer() {
+      return document.getElementById("settingsLogsContainer");
+    }
 
-      await loadLogOverview();
+    function renderLogsMessage(message) {
+      const container = getSettingsLogsContainer();
+      if (!container) return;
+      container.innerHTML = `<div class="rounded-3xl border border-slate-100/70 bg-white/90 px-6 py-5 text-sm font-medium text-slate-600 shadow-card">${escapeHtml(message)}</div>`;
     }
 
     async function loadLogOverview() {
-      const container = document.getElementById("content");
-      if (!container) return;
+      activeLogHex = null;
+      const container = getSettingsLogsContainer();
+      if (!container) {
+        return;
+      }
 
-      container.innerHTML = createStatusCard("Lade Logs...");
+      renderLogsMessage("Lade Logs...");
 
       try {
         const response = await fetch("/log");
@@ -1762,21 +1785,21 @@
         console.error("[Logs] Übersicht konnte nicht geladen werden:", err);
         const message = err && err.message ? err.message : String(err);
         container.innerHTML = `
-          <section class="view-panel mx-auto w-full max-w-4xl space-y-6 p-4">
+          <div class="space-y-4">
             ${createEmptyCard(`Fehler beim Laden der Logs (${escapeHtml(message)})`)}
-          </section>`;
+            <div class="flex justify-center">
+              <button type="button" class="inline-flex items-center gap-2 rounded-2xl bg-sky-500 px-5 py-3 text-sm font-semibold text-white shadow-card transition duration-300 hover:scale-[1.02] hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400" onclick="loadLogOverview()">Erneut versuchen</button>
+            </div>
+          </div>`;
       }
     }
 
     function renderLogOverview(list) {
-      const container = document.getElementById("content");
+      const container = getSettingsLogsContainer();
       if (!container) return;
 
       if (!Array.isArray(list) || list.length === 0) {
-        container.innerHTML = `
-          <section class="view-panel mx-auto w-full max-w-4xl space-y-6 p-4">
-            ${createEmptyCard("Keine Logs vorhanden")}
-          </section>`;
+        container.innerHTML = createEmptyCard("Keine Logs vorhanden");
         return;
       }
 
@@ -1821,22 +1844,7 @@
           </article>`;
       }).join("");
 
-      container.innerHTML = `
-        <section class="view-panel mx-auto w-full max-w-5xl space-y-6 pb-8">
-          <div class="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/70">Logs</p>
-              <h2 class="text-3xl font-semibold text-brand-ink">Flugdatensätze</h2>
-              <p class="text-sm text-slate-500">Wähle ein Flugzeug, um die vollständigen Rohdaten einzusehen.</p>
-            </div>
-            <button type="button" class="inline-flex items-center gap-2 rounded-2xl bg-sky-500 px-5 py-3 text-sm font-semibold text-white shadow-card transition-all duration-300 hover:scale-[1.02] hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400" onclick="loadLogOverview()">
-              Aktualisieren
-            </button>
-          </div>
-          <div class="flex flex-col gap-4">
-            ${cards}
-          </div>
-        </section>`;
+      container.innerHTML = cards;
     }
 
     async function openLogDetail(hex) {
@@ -1846,10 +1854,10 @@
       }
 
       activeLogHex = targetHex;
-      const container = document.getElementById("content");
+      const container = getSettingsLogsContainer();
       if (!container) return;
 
-      container.innerHTML = createStatusCard("Lade Log...");
+      renderLogsMessage("Lade Log...");
 
       try {
         const response = await fetch(`/log?hex=${encodeURIComponent(targetHex)}`);
@@ -1864,31 +1872,29 @@
         renderLogDetail(targetHex, Array.isArray(data) ? data : []);
       } catch (err) {
         console.error("[Logs] Detailansicht konnte nicht geladen werden:", err);
-        const container = document.getElementById("content");
-        if (!container) return;
         const message = err && err.message ? err.message : String(err);
+        const retryHex = escapeHtml(targetHex);
         container.innerHTML = `
-          <section class="view-panel mx-auto w-full max-w-4xl space-y-6 p-4">
+          <div class="space-y-4">
             ${createEmptyCard(`Fehler beim Laden des Logs (${escapeHtml(message)})`)}
-            <div class="flex justify-center">
-              <button type="button" class="inline-flex items-center gap-2 rounded-2xl bg-sky-500 px-5 py-3 text-sm font-semibold text-white shadow-card transition-all duration-300 hover:scale-[1.02] hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400" onclick="returnToLogOverview()">Zurück</button>
+            <div class="flex flex-wrap justify-center gap-3">
+              <button type="button" class="inline-flex items-center gap-2 rounded-2xl bg-slate-200 px-5 py-3 text-sm font-semibold text-slate-600 shadow-card transition duration-300 hover:scale-[1.02] hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300" onclick="returnToLogOverview()">Zurück</button>
+              <button type="button" class="inline-flex items-center gap-2 rounded-2xl bg-brand-purple px-5 py-3 text-sm font-semibold text-white shadow-card transition duration-300 hover:scale-[1.02] hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50" onclick="openLogDetail('${retryHex}')">Erneut versuchen</button>
             </div>
-          </section>`;
+          </div>`;
       }
     }
 
     function renderLogDetail(hex, data) {
-      const container = document.getElementById("content");
+      const container = getSettingsLogsContainer();
       if (!container) return;
 
       if (!Array.isArray(data) || data.length === 0) {
         container.innerHTML = `
-          <section class="view-panel mx-auto w-full max-w-4xl space-y-6 p-4">
-            ${createEmptyCard("Keine Log-Einträge vorhanden")}
-            <div class="flex justify-center">
-              <button type="button" class="inline-flex items-center gap-2 rounded-2xl bg-sky-500 px-5 py-3 text-sm font-semibold text-white shadow-card transition-all duration-300 hover:scale-[1.02] hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400" onclick="returnToLogOverview()">Zurück</button>
-            </div>
-          </section>`;
+          ${createEmptyCard("Keine Log-Einträge vorhanden")}
+          <div class="flex justify-center">
+            <button type="button" class="mt-2 inline-flex items-center gap-2 rounded-2xl bg-slate-200 px-5 py-3 text-sm font-semibold text-slate-600 shadow-card transition duration-300 hover:scale-[1.02] hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300" onclick="returnToLogOverview()">Zurück</button>
+          </div>`;
         return;
       }
 
@@ -1926,9 +1932,10 @@
       const overviewEntry = cachedLogOverview.find(item => item && String(item.hex).toLowerCase() === hex);
       const callsign = overviewEntry && overviewEntry.last ? overviewEntry.last.callsign : (data[data.length - 1]?.callsign ?? "—");
       const headingHex = hex ? hex.toUpperCase() : "—";
+      const latestLabel = escapeHtml(formatDateTime(limited[0]?.time));
 
       container.innerHTML = `
-        <section class="view-panel mx-auto w-full max-w-6xl space-y-6 pb-8">
+        <div class="space-y-6">
           <div class="flex flex-wrap items-center justify-between gap-4">
             <div class="flex items-center gap-3">
               <button type="button" onclick="returnToLogOverview()" class="inline-flex h-11 w-11 items-center justify-center rounded-2xl border border-brand-purple/20 bg-white text-brand-purple shadow-sm transition-transform duration-300 hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/60" aria-label="Zurück zur Übersicht">
@@ -1942,7 +1949,7 @@
                 <p class="text-sm text-slate-500">HEX ${escapeHtml(headingHex)}</p>
               </div>
             </div>
-            <span class="rounded-full bg-brand-purple/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple">${escapeHtml(formatDateTime(limited[0]?.time))}</span>
+            <span class="rounded-full bg-brand-purple/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple">${latestLabel}</span>
           </div>
           <div class="rounded-2xl border border-brand-purple/10 bg-white shadow-card">
             <div class="max-h-[70vh] overflow-auto">
@@ -1962,7 +1969,7 @@
               </table>
             </div>
           </div>
-        </section>`;
+        </div>`;
     }
 
     function returnToLogOverview() {
@@ -2178,7 +2185,8 @@
         { id: "thresholds", label: "Schwellwerte", description: "Grenzwerte für Events festlegen" },
         { id: "notifications", label: "Benachrichtigungen", description: "Push-Benachrichtigungen konfigurieren" },
         { id: "places", label: "Orte verwalten", description: "Eigene Landeplätze pflegen" },
-        { id: "events", label: "Events verwalten", description: "Takeoffs & Landings administrieren" }
+        { id: "events", label: "Events verwalten", description: "Takeoffs & Landings administrieren" },
+        { id: "logs", label: "Logs & Rohdaten", description: "Letzte Flugdaten einsehen" }
       ];
 
       const navHtml = `
@@ -2444,6 +2452,21 @@
               <p id="eventsMessage" class="mt-4 min-h-[1.5rem] text-sm font-semibold text-slate-500"></p>
             </section>
           </section>
+          <section data-settings-section="logs" class="${activeSettingsSection === "logs" ? "" : "hidden"}">
+            <section class="settings-section rounded-3xl bg-white/95 px-6 py-6 shadow-card ring-1 ring-white/50 backdrop-blur">
+              <div class="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                  <span class="text-[0.65rem] uppercase tracking-[0.35em] text-brand-purple/70">Logs</span>
+                  <h3 class="text-xl font-semibold text-slate-900">Flugdatensätze</h3>
+                  <p class="text-sm text-slate-500">Analysiere die letzten Rohdaten deiner Flüge.</p>
+                </div>
+                <button type="button" class="inline-flex items-center gap-2 rounded-full bg-sky-100 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-sky-700 shadow-inner shadow-white/40 transition duration-300 hover:bg-sky-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-200" onclick="loadLogOverview()">
+                  Aktualisieren
+                </button>
+              </div>
+              <div id="settingsLogsContainer" class="mt-6 space-y-4"></div>
+            </section>
+          </section>
         </div>
       `;
 
@@ -2473,6 +2496,7 @@
       renderHexHistoryDropdown();
       handleHexInputChange();
       renderEventsManagementTable(currentEvents);
+      loadLogOverview();
       updateSettingsSectionVisibility();
     }
 


### PR DESCRIPTION
## Summary
- add a dashboard tile to the bottom navigation and show a placeholder dashboard view
- remove the standalone logs view and surface log management within the settings screen
- extend settings navigation with a logs section that reuses the existing log overview and detail logic

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68ceca17a00883318a56e295498481f6