### PR TITLE
Remove stray codex marker from index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@ let events = [];          // Takeoff/Landing-Events
 let flightStatus = {};    // Status- & Verlaufdaten pro Flugzeug
 const fsp = fs.promises;
 const logsDir = path.join(__dirname, "logs");
-codex/add-history-log-endpoint-and-ui-features
 const logsHistoryDir = path.join(__dirname, "logs_history");
 const historyLogsDir = path.join(__dirname, "logs_history");
 const HISTORY_REQUEST_INTERVAL_MS = 2_000;


### PR DESCRIPTION
## Summary
- remove a stray `codex/...` marker in `index.js` so the file parses correctly at runtime

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cfec51a8108331a9ada5304df7d9a9