### PR TITLE
Ensure pages reset scroll position on load

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -89,6 +89,14 @@
       }
     }
   </style>
+  <script>
+    const ensureTopOnLoad = () => {
+      window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+    };
+
+    window.addEventListener("DOMContentLoaded", ensureTopOnLoad);
+    window.addEventListener("pageshow", ensureTopOnLoad);
+  </script>
 </head>
 <body class="min-h-screen bg-brand-frost font-sans text-brand-ink antialiased">
   <div class="flex min-h-[100dvh] flex-col">


### PR DESCRIPTION
## Summary
- add a small script to force the window to scroll to the top when the page loads or is restored from history

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d2fd3f8b248331ab5d175cc7dc4e31