### PR TITLE
feat: build responsive dashboard cards

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="anonymous" />
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin="anonymous"></script>
   <script>
@@ -121,8 +122,16 @@
           <p id="viewTitle" class="text-[0.65rem] uppercase tracking-[0.4em] text-white/70">Map</p>
           <p class="text-sm font-medium text-white/90">Live monitoring</p>
         </div>
-        <div id="headerHex" class="rounded-full bg-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/90">
-          —
+        <div class="flex flex-col items-end gap-2 sm:flex-row sm:items-center sm:gap-3">
+          <div id="headerHex" class="rounded-full bg-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/90">
+            —
+          </div>
+          <span
+            id="flightStatusBadge"
+            class="inline-flex items-center rounded-full border border-white/30 bg-white/10 px-4 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/70"
+          >
+            —
+          </span>
         </div>
       </div>
     </header>
@@ -244,6 +253,13 @@
     let activeLogSource = LOG_SOURCE_LIVE;
     let activeLogHex = null;
     let activeSettingsSection = "aircraft";
+    let dashboardMapInstance = null;
+    let dashboardMapMarker = null;
+    let dashboardRefreshTimer = null;
+    let dashboardChartInstance = null;
+    let latestTelemetry = null;
+    let lastWeatherFetch = { lat: null, lon: null, timestamp: 0 };
+    let lastWeatherData = null;
     const EVENTS_VIEW_OVERVIEW = "overview";
     const EVENTS_VIEW_GROUP = "group";
     const EVENTS_VIEW_DETAIL = "detail";
@@ -309,6 +325,8 @@
       "bg-white/60",
       "text-slate-500"
     ];
+    const DASHBOARD_REFRESH_INTERVAL_MS = 20000;
+    const WEATHER_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
     const viewTitleMap = {
       dashboard: "Dashboard",
       map: "Live Map",
@@ -737,10 +755,37 @@
       }
     }
 
+    function destroyDashboardMap() {
+      if (dashboardMapInstance) {
+        dashboardMapInstance.remove();
+        dashboardMapInstance = null;
+      }
+      dashboardMapMarker = null;
+    }
+
+    function destroyDashboardChart() {
+      if (dashboardChartInstance) {
+        dashboardChartInstance.destroy();
+        dashboardChartInstance = null;
+      }
+    }
+
+    function clearDashboardRefreshTimer() {
+      if (dashboardRefreshTimer) {
+        clearInterval(dashboardRefreshTimer);
+        dashboardRefreshTimer = null;
+      }
+    }
+
     function setActiveView(view) {
       if (view !== "events") {
         cancelDebugNotificationTimer();
         activeEventDetail = null;
+      }
+      if (view !== "dashboard") {
+        destroyDashboardMap();
+        destroyDashboardChart();
+        clearDashboardRefreshTimer();
       }
       activeView = view;
       const buttons = document.querySelectorAll('.nav-item[data-view]');
@@ -830,11 +875,10 @@
       const detectedHex = (await fetchLatestHex()) || (await fetchFirstHexFromLogs());
 
       if (detectedHex) {
-        renderMap(detectedHex);
-      } else if (container) {
-        container.innerHTML = createStatusCard("Keine ICAO Hex verfügbar.");
-        setActiveView("map");
+        setCurrentHex(detectedHex);
       }
+
+      showDashboard();
     }
 
     async function fetchLatestHex() {
@@ -1117,6 +1161,10 @@
         } else {
           renderEventsOverview();
         }
+      } else if (activeView === "dashboard") {
+        renderDashboardRecentEvents(currentEvents);
+        renderDashboardWeeklyChart(currentEvents);
+        updateDashboardFlightMetrics(latestTelemetry, currentEvents);
       }
 
       const settingsEventsList = document.getElementById("eventsList");
@@ -1538,18 +1586,811 @@
       closeSidebar();
       cleanupEventMap();
       cancelDebugNotificationTimer();
+      clearDashboardRefreshTimer();
+      destroyDashboardMap();
+      destroyDashboardChart();
 
       const container = document.getElementById("content");
       if (!container) return;
 
       container.innerHTML = `
-        <section class="view-panel mx-auto w-full max-w-5xl space-y-6 pb-8">
-          <div class="rounded-3xl bg-white/95 px-6 py-8 text-center shadow-card ring-1 ring-white/50 backdrop-blur">
-            <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/70">Dashboard</p>
-            <h2 class="mt-3 text-3xl font-semibold text-brand-ink">In Kürze verfügbar</h2>
-            <p class="mt-2 text-sm text-slate-500">Hier entsteht das zentrale Einsatz-Dashboard.</p>
+        <section class="view-panel mx-auto w-full max-w-6xl space-y-6 pb-10">
+          <div class="grid gap-6 lg:grid-cols-[2fr_1fr]">
+            <article class="rounded-3xl bg-white/95 px-6 py-6 shadow-card ring-1 ring-white/60 backdrop-blur">
+              <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/70">Live Map</p>
+                  <h2 class="text-2xl font-semibold text-brand-ink">Live Map – Current Position</h2>
+                </div>
+              </div>
+              <div class="relative mt-6 h-[20rem] w-full overflow-hidden rounded-2xl border border-slate-200/60 bg-slate-100 shadow-inner sm:h-[24rem]">
+                <div id="dashboardMap" class="h-full w-full"></div>
+                <div id="dashboardMapFallback" class="pointer-events-none absolute inset-0 flex items-center justify-center px-6 text-center text-sm font-medium text-slate-500">
+                  Lade Position...
+                </div>
+              </div>
+            </article>
+            <article class="rounded-3xl bg-white/95 px-6 py-6 shadow-card ring-1 ring-white/60 backdrop-blur">
+              <div class="flex flex-col gap-1">
+                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/70">Flight Data</p>
+                <h2 class="text-2xl font-semibold text-brand-ink">Aktuelle Telemetrie</h2>
+              </div>
+              <div class="mt-6 grid gap-4 sm:grid-cols-3">
+                <div class="rounded-2xl border border-brand-purple/10 bg-white px-5 py-5 shadow-card">
+                  <p class="text-[0.65rem] uppercase tracking-[0.35em] text-brand-purple/70">Speed</p>
+                  <p id="flightSpeedValue" class="mt-3 text-2xl font-semibold text-brand-ink">—</p>
+                  <p class="text-xs font-medium uppercase tracking-[0.25em] text-slate-400">kt</p>
+                </div>
+                <div class="rounded-2xl border border-brand-purple/10 bg-white px-5 py-5 shadow-card">
+                  <p class="text-[0.65rem] uppercase tracking-[0.35em] text-brand-purple/70">Altitude</p>
+                  <p id="flightAltitudeValue" class="mt-3 text-2xl font-semibold text-brand-ink">—</p>
+                  <p class="text-xs font-medium uppercase tracking-[0.25em] text-slate-400">ft</p>
+                </div>
+                <div class="rounded-2xl border border-brand-purple/10 bg-white px-5 py-5 shadow-card">
+                  <p class="text-[0.65rem] uppercase tracking-[0.35em] text-brand-purple/70">Distance</p>
+                  <p id="flightDistanceValue" class="mt-3 text-2xl font-semibold text-brand-ink">—</p>
+                  <p class="text-xs font-medium uppercase tracking-[0.25em] text-slate-400">km</p>
+                </div>
+              </div>
+              <p id="flightDataTimestamp" class="mt-5 text-xs text-slate-500">Aktualisiert: —</p>
+            </article>
           </div>
+          <div class="grid gap-6 lg:grid-cols-[1.4fr_1fr]">
+            <article class="rounded-3xl bg-white/95 px-6 py-6 shadow-card ring-1 ring-white/60 backdrop-blur">
+              <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/70">Statistics</p>
+                  <h2 class="text-2xl font-semibold text-brand-ink">Flüge der letzten 7 Tage</h2>
+                </div>
+                <button
+                  type="button"
+                  class="inline-flex items-center gap-2 rounded-full border border-brand-purple/20 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-brand-purple transition hover:bg-brand-purple/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/40"
+                  onclick="void loadDashboardData()"
+                >
+                  Aktualisieren
+                </button>
+              </div>
+              <div class="relative mt-6 rounded-2xl border border-slate-200/60 bg-white/80 p-4 shadow-inner">
+                <canvas id="dashboardFlightsChart" class="h-[16rem] w-full"></canvas>
+                <div id="dashboardChartEmpty" class="pointer-events-none absolute inset-0 flex items-center justify-center rounded-2xl text-sm font-medium text-slate-500">
+                  Keine Event-Daten verfügbar.
+                </div>
+              </div>
+            </article>
+            <article class="rounded-3xl bg-white/95 px-6 py-6 shadow-card ring-1 ring-white/60 backdrop-blur">
+              <div class="flex flex-col gap-1">
+                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/70">Weather</p>
+                <h2 class="text-2xl font-semibold text-brand-ink">Lokale Bedingungen</h2>
+              </div>
+              <div class="mt-6 flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+                <div class="space-y-4">
+                  <div>
+                    <p class="text-[0.65rem] uppercase tracking-[0.35em] text-brand-purple/70">Temperatur</p>
+                    <p id="weatherTemperature" class="mt-2 text-2xl font-semibold text-brand-ink">—</p>
+                  </div>
+                  <div>
+                    <p class="text-[0.65rem] uppercase tracking-[0.35em] text-brand-purple/70">Wind</p>
+                    <p id="weatherWind" class="mt-2 text-lg font-semibold text-brand-ink">—</p>
+                  </div>
+                  <div>
+                    <p class="text-[0.65rem] uppercase tracking-[0.35em] text-brand-purple/70">Sicht</p>
+                    <p id="weatherVisibility" class="mt-2 text-lg font-semibold text-brand-ink">—</p>
+                  </div>
+                </div>
+                <div class="flex h-20 w-20 items-center justify-center rounded-full bg-brand-purple/10 text-4xl">
+                  <span id="weatherIcon" aria-hidden="true">☀️</span>
+                </div>
+              </div>
+              <p id="weatherMessage" class="mt-5 text-xs text-slate-500">Warte auf Positionsdaten...</p>
+            </article>
+          </div>
+          <article class="rounded-3xl bg-white/95 px-6 py-6 shadow-card ring-1 ring-white/60 backdrop-blur">
+            <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/70">Letzte Events</p>
+                <h2 class="text-2xl font-semibold text-brand-ink">Takeoff &amp; Landing Historie</h2>
+              </div>
+            </div>
+            <div id="dashboardEventsList" class="mt-6 space-y-3"></div>
+            <p id="dashboardEventsEmpty" class="mt-4 text-sm text-slate-500">Noch keine Takeoff- oder Landing-Events erkannt.</p>
+          </article>
         </section>`;
+
+      requestAnimationFrame(() => {
+        initializeDashboardMap();
+        void loadDashboardData();
+      });
+
+      if (typeof window !== "undefined") {
+        dashboardRefreshTimer = setInterval(() => {
+          void loadDashboardData({ silent: true });
+        }, DASHBOARD_REFRESH_INTERVAL_MS);
+      }
+    }
+
+    async function loadDashboardData(options = {}) {
+      const { silent = false } = options;
+      const fallback = document.getElementById("dashboardMapFallback");
+      const timestampEl = document.getElementById("flightDataTimestamp");
+
+      if (!silent && fallback) {
+        fallback.classList.remove("hidden");
+        fallback.textContent = "Lade Position...";
+      }
+
+      try {
+        const [latestResponse, eventsResponse] = await Promise.all([
+          fetch("/latest")
+            .then(res => (res.ok ? res.json() : null))
+            .catch(err => {
+              console.warn("[Dashboard] /latest konnte nicht geladen werden:", err);
+              return null;
+            }),
+          fetchEventsList()
+            .then(list => (Array.isArray(list) ? list : []))
+            .catch(err => {
+              console.warn("[Dashboard] /events konnte nicht geladen werden:", err);
+              return Array.isArray(currentEvents) ? currentEvents : [];
+            })
+        ]);
+
+        const latest = latestResponse && typeof latestResponse === "object"
+          ? latestResponse
+          : null;
+
+        if (Array.isArray(eventsResponse)) {
+          currentEvents = eventsResponse;
+          currentEventGroups = groupEventsByAircraft(currentEvents);
+        }
+
+        latestTelemetry = latest;
+
+        if (latest && latest.hex) {
+          setCurrentHex(latest.hex);
+        }
+
+        updateFlightStatusBadgeFromLatest(latest);
+        updateDashboardFlightMetrics(latest, currentEvents);
+        updateDashboardMapWithLatest(latest);
+        await updateDashboardWeather(latest);
+        renderDashboardWeeklyChart(currentEvents);
+        renderDashboardRecentEvents(currentEvents);
+
+        if (timestampEl) {
+          timestampEl.textContent = `Aktualisiert: ${latest && latest.time ? formatDateTime(latest.time) : "—"}`;
+        }
+      } catch (err) {
+        console.error("[Dashboard] Daten konnten nicht geladen werden:", err);
+        updateFlightStatusBadge(null);
+        if (fallback) {
+          fallback.classList.remove("hidden");
+          fallback.textContent = "Daten konnten nicht geladen werden.";
+        }
+      }
+    }
+
+    function initializeDashboardMap() {
+      const container = document.getElementById("dashboardMap");
+      const fallback = document.getElementById("dashboardMapFallback");
+
+      if (!container) {
+        return;
+      }
+
+      if (dashboardMapInstance) {
+        dashboardMapInstance.remove();
+        dashboardMapInstance = null;
+      }
+      dashboardMapMarker = null;
+
+      if (typeof L === "undefined") {
+        if (fallback) {
+          fallback.classList.remove("hidden");
+          fallback.textContent = "Kartenbibliothek nicht verfügbar.";
+        }
+        return;
+      }
+
+      try {
+        dashboardMapInstance = L.map(container, {
+          attributionControl: true,
+          zoomControl: true
+        });
+
+        const defaultCenter = [51.1657, 10.4515];
+        dashboardMapInstance.setView(defaultCenter, 6);
+
+        L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+          maxZoom: 19,
+          attribution: "&copy; OpenStreetMap-Mitwirkende"
+        }).addTo(dashboardMapInstance);
+
+        if (fallback) {
+          fallback.classList.remove("hidden");
+          fallback.textContent = "Warte auf Positionsdaten...";
+        }
+      } catch (err) {
+        console.error("[Dashboard] Karte konnte nicht initialisiert werden:", err);
+        if (fallback) {
+          fallback.classList.remove("hidden");
+          fallback.textContent = "Karte konnte nicht geladen werden.";
+        }
+      }
+    }
+
+    function updateDashboardMapWithLatest(latest) {
+      const fallback = document.getElementById("dashboardMapFallback");
+
+      if (!latest || typeof latest !== "object") {
+        if (fallback) {
+          fallback.classList.remove("hidden");
+          fallback.textContent = "Keine Positionsdaten verfügbar.";
+        }
+        return;
+      }
+
+      const lat = Number(latest.lat);
+      const lon = Number(latest.lon);
+      if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+        if (fallback) {
+          fallback.classList.remove("hidden");
+          fallback.textContent = "Keine Positionsdaten verfügbar.";
+        }
+        return;
+      }
+
+      if (!dashboardMapInstance) {
+        initializeDashboardMap();
+      }
+
+      if (!dashboardMapInstance || typeof L === "undefined") {
+        if (fallback) {
+          fallback.classList.remove("hidden");
+          fallback.textContent = "Karte konnte nicht geladen werden.";
+        }
+        return;
+      }
+
+      const position = [lat, lon];
+
+      if (!dashboardMapMarker) {
+        dashboardMapMarker = L.marker(position, { title: "Aktuelle Position" }).addTo(dashboardMapInstance);
+      } else {
+        dashboardMapMarker.setLatLng(position);
+      }
+
+      dashboardMapInstance.setView(position, 12);
+
+      if (fallback) {
+        fallback.classList.add("hidden");
+      }
+    }
+
+    function updateDashboardFlightMetrics(latest, events) {
+      const speedEl = document.getElementById("flightSpeedValue");
+      const altitudeEl = document.getElementById("flightAltitudeValue");
+      const distanceEl = document.getElementById("flightDistanceValue");
+
+      const speed = latest && latest.gs !== undefined ? Number(latest.gs) : null;
+      const altitude = latest && latest.alt !== undefined ? Number(latest.alt) : null;
+      const distance = calculateDistanceFromEvents(latest, events);
+
+      if (speedEl) {
+        speedEl.textContent = Number.isFinite(speed) ? Math.round(speed).toString() : "—";
+      }
+      if (altitudeEl) {
+        altitudeEl.textContent = Number.isFinite(altitude) ? Math.round(altitude).toString() : "—";
+      }
+      if (distanceEl) {
+        distanceEl.textContent = Number.isFinite(distance) ? distance.toFixed(1) : "—";
+      }
+    }
+
+    function calculateDistanceFromEvents(latest, events) {
+      if (!latest || typeof latest !== "object") {
+        return null;
+      }
+
+      const lat = Number(latest.lat);
+      const lon = Number(latest.lon);
+      if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+        return null;
+      }
+
+      const relevantEvents = Array.isArray(events)
+        ? events
+            .filter(item => {
+              if (!item || typeof item !== "object") {
+                return false;
+              }
+              const type = typeof item.type === "string" ? item.type.toLowerCase() : "";
+              if (type !== "takeoff" && type !== "landing") {
+                return false;
+              }
+              const evLat = Number(item.lat);
+              const evLon = Number(item.lon);
+              return Number.isFinite(evLat) && Number.isFinite(evLon);
+            })
+            .sort((a, b) => {
+              const timeA = new Date(a.time).getTime();
+              const timeB = new Date(b.time).getTime();
+              const validA = Number.isFinite(timeA);
+              const validB = Number.isFinite(timeB);
+              if (validA && validB) {
+                return timeB - timeA;
+              }
+              if (validA && !validB) {
+                return -1;
+              }
+              if (!validA && validB) {
+                return 1;
+              }
+              return 0;
+            })
+        : [];
+
+      if (relevantEvents.length === 0) {
+        return null;
+      }
+
+      const latestEvent = relevantEvents[0];
+      const eventLat = Number(latestEvent.lat);
+      const eventLon = Number(latestEvent.lon);
+
+      if (!Number.isFinite(eventLat) || !Number.isFinite(eventLon)) {
+        return null;
+      }
+
+      const distance = haversineDistanceKm(lat, lon, eventLat, eventLon);
+      return Number.isFinite(distance) ? distance : null;
+    }
+
+    function haversineDistanceKm(lat1, lon1, lat2, lon2) {
+      const toRad = deg => (deg * Math.PI) / 180;
+      const R = 6371;
+      const dLat = toRad(lat2 - lat1);
+      const dLon = toRad(lon2 - lon1);
+      const a = Math.sin(dLat / 2) ** 2
+        + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+      const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+      return R * c;
+    }
+
+    function renderDashboardWeeklyChart(events) {
+      const canvas = document.getElementById("dashboardFlightsChart");
+      const emptyState = document.getElementById("dashboardChartEmpty");
+
+      if (!canvas) {
+        return;
+      }
+
+      if (dashboardChartInstance) {
+        dashboardChartInstance.destroy();
+        dashboardChartInstance = null;
+      }
+
+      if (typeof Chart === "undefined") {
+        if (emptyState) {
+          emptyState.classList.remove("hidden");
+          emptyState.textContent = "Diagramm konnte nicht geladen werden.";
+        }
+        return;
+      }
+
+      const start = new Date();
+      start.setHours(0, 0, 0, 0);
+      start.setDate(start.getDate() - 6);
+
+      const dayKeys = [];
+      for (let i = 0; i < 7; i += 1) {
+        const day = new Date(start);
+        day.setDate(start.getDate() + i);
+        dayKeys.push(day.toISOString().slice(0, 10));
+      }
+
+      const counts = new Map(dayKeys.map(key => [key, 0]));
+
+      if (Array.isArray(events)) {
+        events.forEach(event => {
+          if (!event || typeof event !== "object" || !event.time) {
+            return;
+          }
+          const type = typeof event.type === "string" ? event.type.toLowerCase() : "";
+          if (type !== "takeoff" && type !== "landing") {
+            return;
+          }
+          const date = new Date(event.time);
+          if (Number.isNaN(date.getTime())) {
+            return;
+          }
+          const key = date.toISOString().slice(0, 10);
+          if (counts.has(key)) {
+            if (type === "takeoff") {
+              counts.set(key, (counts.get(key) || 0) + 1);
+            }
+          }
+        });
+      }
+
+      const labels = dayKeys.map(key => formatDateLabel(key));
+      const data = dayKeys.map(key => counts.get(key) || 0);
+
+      const hasData = data.some(value => value > 0);
+      if (emptyState) {
+        emptyState.classList.toggle("hidden", hasData);
+      }
+
+      const context = canvas.getContext("2d");
+      dashboardChartInstance = new Chart(context, {
+        type: "bar",
+        data: {
+          labels,
+          datasets: [
+            {
+              label: "Flüge",
+              data,
+              backgroundColor: "rgba(111, 93, 247, 0.45)",
+              hoverBackgroundColor: "rgba(111, 93, 247, 0.65)",
+              borderRadius: 12,
+              maxBarThickness: 42
+            }
+          ]
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            x: {
+              grid: { display: false },
+              ticks: { font: { family: "Inter" } }
+            },
+            y: {
+              beginAtZero: true,
+              grid: { color: "rgba(148, 163, 184, 0.25)" },
+              ticks: {
+                precision: 0,
+                stepSize: 1,
+                font: { family: "Inter" }
+              }
+            }
+          },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              backgroundColor: "rgba(28, 28, 30, 0.9)",
+              displayColors: false,
+              titleFont: { family: "Inter", weight: "600" },
+              bodyFont: { family: "Inter", weight: "500" },
+              callbacks: {
+                label: context => `Flüge: ${context.parsed.y}`
+              }
+            }
+          }
+        }
+      });
+    }
+
+    function renderDashboardRecentEvents(events) {
+      const list = document.getElementById("dashboardEventsList");
+      const empty = document.getElementById("dashboardEventsEmpty");
+
+      if (!list) {
+        return;
+      }
+
+      const normalized = Array.isArray(events)
+        ? events
+            .filter(event => {
+              if (!event || typeof event !== "object") {
+                return false;
+              }
+              const type = typeof event.type === "string" ? event.type.toLowerCase() : "";
+              return type === "takeoff" || type === "landing";
+            })
+            .sort((a, b) => {
+              const timeA = new Date(a.time).getTime();
+              const timeB = new Date(b.time).getTime();
+              const validA = Number.isFinite(timeA);
+              const validB = Number.isFinite(timeB);
+              if (validA && validB) {
+                return timeB - timeA;
+              }
+              if (validA && !validB) {
+                return -1;
+              }
+              if (!validA && validB) {
+                return 1;
+              }
+              return 0;
+            })
+        : [];
+
+      const items = normalized.slice(0, 6);
+
+      if (items.length === 0) {
+        list.innerHTML = "";
+        if (empty) {
+          empty.classList.remove("hidden");
+        }
+        return;
+      }
+
+      list.innerHTML = items.map(renderDashboardEventCard).join("");
+      if (empty) {
+        empty.classList.add("hidden");
+      }
+    }
+
+    function renderDashboardEventCard(event) {
+      const type = typeof event?.type === "string" ? event.type.toLowerCase() : "";
+      const isLanding = type === "landing";
+      const iconClasses = isLanding
+        ? "bg-emerald-100 text-emerald-600"
+        : "bg-rose-100 text-rose-600";
+      const iconSvg = isLanding
+        ? '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3v5.25a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0015 8.25V3m0 0l-3-3m3 3l3-3M3 21h18" /></svg>'
+        : '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5"><path stroke-linecap="round" stroke-linejoin="round" d="M3 21v-5.25A2.25 2.25 0 015.25 13.5h7.5A2.25 2.25 0 0115 15.75V21m0 0l-3 3m3-3l3 3M3 3h18" /></svg>';
+      const callsign = event && typeof event.callsign === "string" && event.callsign.trim()
+        ? event.callsign.trim()
+        : (event && event.hex ? String(event.hex).trim().toUpperCase() : "Unbekannt");
+      const timeLabel = event && event.time ? formatDateTime(event.time) : "—";
+      const locationLabel = formatDashboardLocation(event);
+      const coordinateLabel = formatDashboardCoordinates(event);
+      const statusLabel = isLanding ? "Landing" : "Takeoff";
+
+      return `<article class="flex flex-col gap-4 rounded-2xl border border-slate-200/70 bg-white/90 px-4 py-4 shadow-card transition hover:border-brand-purple/40 hover:shadow-lg md:flex-row md:items-center md:justify-between">
+        <div class="flex items-center gap-3">
+          <span class="inline-flex h-10 w-10 items-center justify-center rounded-2xl ${iconClasses}">
+            ${iconSvg}
+          </span>
+          <div>
+            <p class="text-sm font-semibold text-brand-ink">${escapeHtml(callsign)}</p>
+            <p class="text-xs uppercase tracking-[0.3em] text-slate-400">${escapeHtml(statusLabel)}</p>
+            <p class="text-xs text-slate-500">${escapeHtml(timeLabel)}</p>
+          </div>
+        </div>
+        <div class="flex flex-col gap-3 text-sm text-slate-600 sm:flex-row sm:items-center sm:gap-6">
+          <div class="flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5 text-brand-purple/70">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.5-7.5 12-7.5 12s-7.5-4.5-7.5-12a7.5 7.5 0 1115 0z" />
+            </svg>
+            <span class="font-medium">${escapeHtml(locationLabel)}</span>
+          </div>
+          <div class="flex items-center gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5 text-brand-purple/70">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m6-6H6" />
+            </svg>
+            <span>${escapeHtml(coordinateLabel)}</span>
+          </div>
+        </div>
+      </article>`;
+    }
+
+    function formatDashboardLocation(event) {
+      if (!event || typeof event !== "object") {
+        return "Unbekannter Ort";
+      }
+
+      const place = event.place && typeof event.place === "object" ? event.place : null;
+      if (place) {
+        const candidates = ["name", "label", "airport", "title"];
+        for (const key of candidates) {
+          if (typeof place[key] === "string" && place[key].trim()) {
+            return place[key].trim();
+          }
+        }
+      }
+
+      if (typeof event.location === "string" && event.location.trim()) {
+        return event.location.trim();
+      }
+
+      return "Unbekannter Ort";
+    }
+
+    function formatDashboardCoordinates(event) {
+      if (!event || typeof event !== "object") {
+        return "Keine Koordinaten";
+      }
+
+      const lat = formatCoordinate(event.lat);
+      const lon = formatCoordinate(event.lon);
+      if (lat === "—" || lon === "—") {
+        return "Keine Koordinaten";
+      }
+      return `${lat}, ${lon}`;
+    }
+
+    function updateFlightStatusBadgeFromLatest(latest) {
+      updateFlightStatusBadge(deriveFlightStatus(latest));
+    }
+
+    function deriveFlightStatus(latest) {
+      if (!latest || typeof latest !== "object") {
+        return null;
+      }
+
+      const thresholds = getEffectiveThresholds();
+      const altitude = Number(latest.alt);
+      const speed = Number(latest.gs);
+
+      if ((Number.isFinite(altitude) && altitude > thresholds.altitude)
+        || (Number.isFinite(speed) && speed > thresholds.speed)) {
+        return "air";
+      }
+
+      if (Number.isFinite(altitude) || Number.isFinite(speed)) {
+        return "ground";
+      }
+
+      return null;
+    }
+
+    function getEffectiveThresholds() {
+      const cfg = currentConfigCache || {};
+      const altitude = Number(cfg.altitudeThresholdFt);
+      const speed = Number(cfg.speedThresholdKt);
+      return {
+        altitude: Number.isFinite(altitude) ? altitude : DEFAULT_ALTITUDE_THRESHOLD_FT,
+        speed: Number.isFinite(speed) ? speed : DEFAULT_SPEED_THRESHOLD_KT
+      };
+    }
+
+    function updateFlightStatusBadge(status) {
+      const badge = document.getElementById("flightStatusBadge");
+      if (!badge) {
+        return;
+      }
+
+      const base = "inline-flex items-center rounded-full border px-4 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.35em]";
+      let className = `${base} border-white/30 bg-white/10 text-white/70`;
+      let label = "—";
+
+      if (status === "air") {
+        className = `${base} border-emerald-200/60 bg-emerald-500/40 text-white`;
+        label = "Luft";
+      } else if (status === "ground") {
+        className = `${base} border-amber-200/60 bg-amber-400/50 text-white`;
+        label = "Boden";
+      }
+
+      badge.className = className;
+      badge.textContent = label;
+    }
+
+    async function updateDashboardWeather(latest) {
+      const statusEl = document.getElementById("weatherMessage");
+      if (!statusEl) {
+        return;
+      }
+
+      const lat = Number(latest && latest.lat);
+      const lon = Number(latest && latest.lon);
+
+      if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+        applyWeatherToCard(null);
+        statusEl.textContent = "Keine Positionsdaten verfügbar.";
+        return;
+      }
+
+      const now = Date.now();
+      if (
+        lastWeatherData
+        && lastWeatherFetch
+        && lastWeatherFetch.lat === lat
+        && lastWeatherFetch.lon === lon
+        && now - lastWeatherFetch.timestamp < WEATHER_REFRESH_INTERVAL_MS
+      ) {
+        applyWeatherToCard(lastWeatherData);
+        statusEl.textContent = lastWeatherData.updatedAt
+          ? `Aktualisiert: ${formatDateTime(lastWeatherData.updatedAt)}`
+          : "Aktualisiert";
+        return;
+      }
+
+      statusEl.textContent = "Lade Wetterdaten...";
+
+      try {
+        const params = new URLSearchParams({
+          latitude: lat.toString(),
+          longitude: lon.toString(),
+          current: "temperature_2m,wind_speed_10m,visibility,weather_code",
+          timezone: "auto"
+        });
+        const response = await fetch(`https://api.open-meteo.com/v1/forecast?${params.toString()}`);
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const payload = await response.json();
+        const current = payload && payload.current;
+        if (!current) {
+          throw new Error("Keine Wetterdaten verfügbar");
+        }
+
+        const weather = {
+          temperature: Number(current.temperature_2m),
+          wind: Number(current.wind_speed_10m),
+          visibility: Number(current.visibility),
+          code: current.weather_code,
+          updatedAt: current.time
+        };
+
+        lastWeatherFetch = { lat, lon, timestamp: now };
+        lastWeatherData = weather;
+
+        applyWeatherToCard(weather);
+        statusEl.textContent = weather.updatedAt
+          ? `Aktualisiert: ${formatDateTime(weather.updatedAt)}`
+          : "Aktualisiert";
+      } catch (err) {
+        console.warn("[Dashboard] Wetter konnte nicht geladen werden:", err);
+        applyWeatherToCard(null);
+        statusEl.textContent = "Wetterdaten konnten nicht geladen werden.";
+      }
+    }
+
+    function applyWeatherToCard(weather) {
+      const tempEl = document.getElementById("weatherTemperature");
+      const windEl = document.getElementById("weatherWind");
+      const visibilityEl = document.getElementById("weatherVisibility");
+      const iconEl = document.getElementById("weatherIcon");
+
+      if (!tempEl || !windEl || !visibilityEl || !iconEl) {
+        return;
+      }
+
+      if (!weather) {
+        tempEl.textContent = "—";
+        windEl.textContent = "—";
+        visibilityEl.textContent = "—";
+        iconEl.textContent = "☀️";
+        iconEl.title = "Keine Daten";
+        return;
+      }
+
+      const visibilityKm = Number.isFinite(weather.visibility)
+        ? Math.max(weather.visibility / 1000, 0)
+        : null;
+
+      tempEl.textContent = Number.isFinite(weather.temperature)
+        ? `${weather.temperature.toFixed(1)} °C`
+        : "—";
+      windEl.textContent = Number.isFinite(weather.wind)
+        ? `${Math.round(weather.wind)} km/h`
+        : "—";
+      visibilityEl.textContent = Number.isFinite(visibilityKm)
+        ? `${visibilityKm.toFixed(1)} km`
+        : "—";
+
+      const icon = interpretWeatherCode(weather.code);
+      iconEl.textContent = icon.icon;
+      iconEl.title = icon.label;
+    }
+
+    function interpretWeatherCode(code) {
+      const value = Number(code);
+      if (!Number.isFinite(value)) {
+        return { icon: "☀️", label: "Keine Daten" };
+      }
+
+      const rainCodes = new Set([51, 53, 55, 56, 57, 61, 63, 65, 66, 67, 80, 81, 82, 95, 96, 99]);
+      const snowCodes = new Set([71, 73, 75, 77, 85, 86]);
+
+      if (value === 0) {
+        return { icon: "☀️", label: "Klar" };
+      }
+      if ([1, 2, 3, 45, 48].includes(value)) {
+        return { icon: "⛅", label: "Bewölkt" };
+      }
+      if (rainCodes.has(value)) {
+        return { icon: "🌧️", label: "Regen" };
+      }
+      if (snowCodes.has(value)) {
+        return { icon: "❄️", label: "Schnee" };
+      }
+
+      return { icon: "⛅", label: "Wetter" };
     }
 
     function showADSB() {
@@ -2782,6 +3623,11 @@
           throw new Error(`Serverantwort ${res.status}`);
         }
         const d = await res.json();
+        latestTelemetry = d && typeof d === "object" ? d : null;
+        if (latestTelemetry && latestTelemetry.hex) {
+          setCurrentHex(latestTelemetry.hex);
+        }
+        updateFlightStatusBadgeFromLatest(latestTelemetry);
         const grid = document.getElementById("latestGrid");
         const empty = document.getElementById("latestEmpty");
         const timestampBadge = document.getElementById("latestTimestamp");


### PR DESCRIPTION
## Summary
- build the dashboard view with live map, flight metrics, weather widget, statistics chart, and recent event cards
- load dynamic data for the dashboard including Leaflet markers, flight status badge, and periodic refreshes
- integrate Chart.js and a weather service to visualise weekly activity and current conditions

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_b_68d4297ce92c83319b5d5e37a78b9e3e