### PR TITLE
Adjust header layout and sizing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -155,24 +155,24 @@
 </head>
 <body class="min-h-screen bg-brand-frost font-sans text-brand-ink antialiased">
   <div class="flex min-h-[100dvh] flex-col">
-    <header class="app-header z-40 bg-gradient-to-r from-brand-purple via-brand-red to-brand-purple px-4 pb-4 safe-area-top text-white shadow-lg shadow-brand-red/30 sm:px-6">
-      <div class="mx-auto flex w-full max-w-6xl flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div class="space-y-1">
-          <p class="text-[0.65rem] uppercase tracking-[0.45em] text-white/70">Control Center</p>
-          <h1 class="text-2xl font-semibold leading-tight">Heli Tracker</h1>
+    <header class="app-header z-40 bg-gradient-to-r from-brand-purple via-brand-red to-brand-purple px-4 py-3 safe-area-top text-white shadow-lg shadow-brand-red/30 sm:px-5">
+      <div class="mx-auto flex w-full max-w-6xl flex-col gap-3 sm:flex-row sm:items-center">
+        <div class="space-y-0.5">
+          <p class="text-[0.6rem] uppercase tracking-[0.45em] text-white/70">Control Center</p>
+          <h1 class="text-xl font-semibold leading-snug">Heli Tracker</h1>
         </div>
-        <div class="flex flex-1 items-center justify-between gap-4 sm:justify-end">
+        <div class="flex flex-1 items-start justify-between gap-3 sm:items-center sm:justify-end">
           <div class="hidden text-right sm:block">
-            <p id="viewTitle" class="text-[0.65rem] uppercase tracking-[0.4em] text-white/70">Map</p>
-            <p class="text-sm font-medium text-white/90">Live monitoring</p>
+            <p id="viewTitle" class="text-[0.6rem] uppercase tracking-[0.4em] text-white/70">Map</p>
+            <p class="text-xs font-medium text-white/90">Live monitoring</p>
           </div>
           <div class="flex flex-col items-end gap-2 sm:flex-row sm:items-center sm:gap-3">
-            <div id="headerCallsign" class="rounded-full bg-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/90">
+            <div id="headerCallsign" class="rounded-full bg-white/20 px-4 py-1.5 text-[0.7rem] font-semibold uppercase tracking-[0.35em] text-white/90 sm:ml-auto">
               —
             </div>
             <span
               id="flightStatusBadge"
-              class="inline-flex items-center rounded-full border border-white/30 bg-white/10 px-4 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white/70"
+              class="inline-flex items-center rounded-full border border-white/30 bg-white/10 px-4 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.35em] text-white/70"
             >
               —
             </span>


### PR DESCRIPTION
## Summary
- reduce the header padding and typography to make the top bar more compact
- align the callsign and status badges to the right and adjust their sizing for consistency

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68d8025a893883319cb5f45dca4ed828