### PR TITLE
Adjust Replit deployment configuration

### DIFF
--- a/.replit
+++ b/.replit
@@ -86,7 +86,7 @@ pattern = "**/{*.js,*.jsx,*.ts,*.tsx,*.json}"
 start = "typescript-language-server --stdio"
 
 [deployment]
-run = ["sh", "-c", "node index.js"]
+run = ["sh", "-c", "git pull origin main && node index.js"]
 deploymentTarget = "gce"
 
 [agent]
@@ -95,19 +95,5 @@ expertMode = true
 [[ports]]
 localPort = 3000
 externalPort = 80
-
-[[ports]]
-localPort = 32949
-externalPort = 3001
-exposeLocalhost = true
-
-[[ports]]
-localPort = 36001
-externalPort = 3002
-
-[[ports]]
-localPort = 44129
-externalPort = 3000
-exposeLocalhost = true
 
 


### PR DESCRIPTION
## Summary
- update the deployment command to pull the latest changes before starting the Node.js server
- collapse duplicate port exposure entries down to a single 3000 -> 80 mapping for Replit hosting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d992c232e08331b2e569e4118b5bcb